### PR TITLE
EN6-117 introduced support for existing Keycloak

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![Build Status](https://jenkins.entandocloud.com/buildStatus/icon?job=de-entando-k8s-custom-model-master)](https://jenkins.entandocloud.com/view/Digital%20Exchange/job/de-entando-k8s-custom-model-master/)
+[![Coverage Status](https://coveralls.io/repos/github/entando/entando-k8s-custom-model/badge.svg?branch=master)](https://coveralls.io/github/entando/entando-k8s-custom-model?branch=master)
+
+
 # entando-k8s-custom-model
 Entando's Custom Resource Definition model for Kubernetes. Used in our custom controllers as well as our Kubernetes 
 infrastructure. Use this project when integrating Entando and Kubernetes.

--- a/pom.xml
+++ b/pom.xml
@@ -306,6 +306,11 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.eluder.coveralls</groupId>
+                <artifactId>coveralls-maven-plugin</artifactId>
+                <version>4.3.0</version>
+            </plugin>
+            <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.0</version>
                 <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
         <org.slf4j.simpleLogger.log.io.fabric8>debug</org.slf4j.simpleLogger.log.io.fabric8>
         <org.slf4j.simpleLogger.log.org.jboss.weld>debug</org.slf4j.simpleLogger.log.org.jboss.weld>
         <fabric8.version>4.1.3</fabric8.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <issueManagement>
         <system>Github</system>

--- a/src/main/java/org/entando/kubernetes/model/HasIngress.java
+++ b/src/main/java/org/entando/kubernetes/model/HasIngress.java
@@ -2,9 +2,9 @@ package org.entando.kubernetes.model;
 
 import java.util.Optional;
 
-public interface HasIngress extends EntandoCustomResource {
+public interface HasIngress {
 
     Optional<String> getIngressHostName();
 
-    Optional<Boolean> getTlsEnabled();
+    Optional<String> getTlsSecretName();
 }

--- a/src/main/java/org/entando/kubernetes/model/RequiresKeycloak.java
+++ b/src/main/java/org/entando/kubernetes/model/RequiresKeycloak.java
@@ -1,9 +1,9 @@
 package org.entando.kubernetes.model;
 
-public interface RequiresKeycloak extends EntandoCustomResource {
+import java.util.Optional;
 
-    String getKeycloakServerNamespace();
+public interface RequiresKeycloak {
 
-    String getKeycloakServerName();
+    Optional<String> getKeycloakSecretToUse();
 
 }

--- a/src/main/java/org/entando/kubernetes/model/app/EntandoApp.java
+++ b/src/main/java/org/entando/kubernetes/model/app/EntandoApp.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.CustomResource;
 import java.util.Optional;
+import org.entando.kubernetes.model.EntandoCustomResource;
 import org.entando.kubernetes.model.EntandoCustomResourceStatus;
 import org.entando.kubernetes.model.HasIngress;
 import org.entando.kubernetes.model.RequiresKeycloak;
@@ -18,7 +19,7 @@ import org.entando.kubernetes.model.RequiresKeycloak;
 @JsonInclude(Include.NON_NULL)
 @JsonAutoDetect(fieldVisibility = Visibility.ANY, isGetterVisibility = Visibility.NONE, getterVisibility = Visibility.NONE,
         setterVisibility = Visibility.NONE)
-public class EntandoApp extends CustomResource implements HasIngress, RequiresKeycloak {
+public class EntandoApp extends CustomResource implements HasIngress, RequiresKeycloak, EntandoCustomResource {
 
     public static final String CRD_NAME = "entandoapps.entando.org";
 
@@ -68,17 +69,12 @@ public class EntandoApp extends CustomResource implements HasIngress, RequiresKe
     }
 
     @Override
-    public Optional<Boolean> getTlsEnabled() {
-        return getSpec().getTlsEnabled();
+    public Optional<String> getTlsSecretName() {
+        return getSpec().getTlsSecretName();
     }
 
     @Override
-    public String getKeycloakServerNamespace() {
-        return getSpec().getKeycloakServerNamespace();
-    }
-
-    @Override
-    public String getKeycloakServerName() {
-        return getSpec().getKeycloakServerName();
+    public Optional<String> getKeycloakSecretToUse() {
+        return getSpec().getKeycloakSecretToUse();
     }
 }

--- a/src/main/java/org/entando/kubernetes/model/app/EntandoAppOperationFactory.java
+++ b/src/main/java/org/entando/kubernetes/model/app/EntandoAppOperationFactory.java
@@ -1,0 +1,58 @@
+package org.entando.kubernetes.model.app;
+
+import static java.lang.Thread.sleep;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.internal.CustomResourceOperationsImpl;
+import java.util.List;
+
+public final class EntandoAppOperationFactory {
+
+    private static final int NOT_FOUND = 404;
+    private static CustomResourceDefinition entandoAppCrd;
+
+    private EntandoAppOperationFactory() {
+    }
+
+    public static CustomResourceOperationsImpl<EntandoApp, EntandoAppList,
+            DoneableEntandoApp> produceAllEntandoApps(
+            KubernetesClient client) throws InterruptedException {
+        synchronized (EntandoAppOperationFactory.class) {
+            entandoAppCrd = client.customResourceDefinitions().withName(EntandoApp.CRD_NAME).get();
+            if (entandoAppCrd == null) {
+                List<HasMetadata> list = client.load(Thread.currentThread().getContextClassLoader()
+                        .getResourceAsStream("crd/EntandoAppCRD.yaml")).get();
+                entandoAppCrd = (CustomResourceDefinition) list.get(0);
+                // see issue https://github.com/fabric8io/kubernetes-client/issues/1486
+                entandoAppCrd.getSpec().getValidation().getOpenAPIV3Schema().setDependencies(null);
+                client.customResourceDefinitions().create(entandoAppCrd);
+            }
+
+        }
+        CustomResourceOperationsImpl<EntandoApp, EntandoAppList,
+                DoneableEntandoApp>
+                oper = (CustomResourceOperationsImpl<EntandoApp, EntandoAppList,
+                DoneableEntandoApp>) client
+                .customResources(entandoAppCrd, EntandoApp.class, EntandoAppList.class,
+                        DoneableEntandoApp.class);
+        while (notAvailable(oper)) {
+            sleep(100);
+        }
+        return oper;
+    }
+
+    private static boolean notAvailable(
+            CustomResourceOperationsImpl<EntandoApp, EntandoAppList,
+                    DoneableEntandoApp> oper) {
+        try {
+            oper.inNamespace("default").list().getItems().size();
+            return false;
+        } catch (KubernetesClientException e) {
+            return e.getCode() == NOT_FOUND;
+        }
+    }
+
+}

--- a/src/main/java/org/entando/kubernetes/model/app/EntandoAppSpec.java
+++ b/src/main/java/org/entando/kubernetes/model/app/EntandoAppSpec.java
@@ -10,23 +10,26 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.Optional;
 import org.entando.kubernetes.model.DbmsImageVendor;
+import org.entando.kubernetes.model.HasIngress;
 import org.entando.kubernetes.model.JeeServer;
+import org.entando.kubernetes.model.RequiresKeycloak;
 
 @JsonSerialize
 @JsonDeserialize
 @JsonInclude(Include.NON_NULL)
 @JsonAutoDetect(fieldVisibility = Visibility.ANY, isGetterVisibility = Visibility.NONE, getterVisibility = Visibility.NONE,
         setterVisibility = Visibility.NONE)
-public class EntandoAppSpec {
+public class EntandoAppSpec implements RequiresKeycloak, HasIngress {
 
-    private JeeServer jeeServer;
+    private JeeServer standardServerImage;
+    private String customServerImage;
     private DbmsImageVendor dbms;
     private String ingressHostName;
-    private Boolean tlsEnabled;
+    private String tlsSecretName;
     private String entandoImageVersion;
-    private Integer replicas; // TODO distinguish between dbReplicas and jeeServer replicas
-    private String keycloakServerNamespace;
-    private String keycloakServerName;
+    private Integer replicas; // TODO distinguish between dbReplicas and standardServerImage replicas
+    private String keycloakSecretToUse;
+    private String clusterInfrastructureToUse;
 
     public EntandoAppSpec() {
         super();
@@ -35,29 +38,35 @@ public class EntandoAppSpec {
     /**
      * Only for use from the builder.
      */
-    EntandoAppSpec(JeeServer jeeServer, DbmsImageVendor dbms, String ingressHostName,
-            int replicas, String entandoImageVersion, Boolean tlsEnabled, String keycloakServerNamespace,
-            String keycloakServerName) {
-        this.jeeServer = jeeServer;
+    EntandoAppSpec(JeeServer standardServerImage, String customServerImage, DbmsImageVendor dbms, String ingressHostName, int replicas,
+            String entandoImageVersion,
+            String tlsSecretName, String keycloakSecretToUse, String clusterInfrastructureToUse) {
+        this.standardServerImage = standardServerImage;
+        this.customServerImage = customServerImage;
         this.dbms = dbms;
         this.ingressHostName = ingressHostName;
         this.replicas = replicas;
         this.entandoImageVersion = entandoImageVersion;
-        this.tlsEnabled = tlsEnabled;
-        this.keycloakServerNamespace = keycloakServerNamespace;
-        this.keycloakServerName = keycloakServerName;
+        this.tlsSecretName = tlsSecretName;
+        this.keycloakSecretToUse = keycloakSecretToUse;
+        this.clusterInfrastructureToUse = clusterInfrastructureToUse;
     }
 
-    public String getKeycloakServerNamespace() {
-        return keycloakServerNamespace;
+    @Override
+    public Optional<String> getKeycloakSecretToUse() {
+        return ofNullable(keycloakSecretToUse);
     }
 
-    public String getKeycloakServerName() {
-        return keycloakServerName;
+    public Optional<String> getClusterInfrastructureTouse() {
+        return ofNullable(clusterInfrastructureToUse);
     }
 
-    public Optional<JeeServer> getJeeServer() {
-        return ofNullable(jeeServer);
+    public Optional<JeeServer> getStandardServerImage() {
+        return ofNullable(standardServerImage);
+    }
+
+    public Optional<String> getCustomServerImage() {
+        return ofNullable(customServerImage);
     }
 
     public Optional<String> getEntandoImageVersion() {
@@ -68,12 +77,14 @@ public class EntandoAppSpec {
         return ofNullable(dbms);
     }
 
+    @Override
     public Optional<String> getIngressHostName() {
         return ofNullable(ingressHostName);
     }
 
-    public Optional<Boolean> getTlsEnabled() {
-        return ofNullable(tlsEnabled);
+    @Override
+    public Optional<String> getTlsSecretName() {
+        return ofNullable(tlsSecretName);
     }
 
     public Optional<Integer> getReplicas() {

--- a/src/main/java/org/entando/kubernetes/model/app/EntandoAppSpec.java
+++ b/src/main/java/org/entando/kubernetes/model/app/EntandoAppSpec.java
@@ -33,7 +33,7 @@ public class EntandoAppSpec {
     }
 
     /**
-     * Only for use from the builder
+     * Only for use from the builder.
      */
     EntandoAppSpec(JeeServer jeeServer, DbmsImageVendor dbms, String ingressHostName,
             int replicas, String entandoImageVersion, Boolean tlsEnabled, String keycloakServerNamespace,

--- a/src/main/java/org/entando/kubernetes/model/app/EntandoAppSpecBuilder.java
+++ b/src/main/java/org/entando/kubernetes/model/app/EntandoAppSpecBuilder.java
@@ -5,41 +5,42 @@ import org.entando.kubernetes.model.JeeServer;
 
 public class EntandoAppSpecBuilder<N extends EntandoAppSpecBuilder> {
 
-    private JeeServer jeeServer;
+    private JeeServer standardServerImage;
     private DbmsImageVendor dbms;
     private String ingressHostName;
-    private Boolean tlsEnabled;
+    private String tlsSecretName;
     private String entandoImageVersion;
     private Integer replicas;
-    private String keycloakServerNamespace;
-    private String keycloakServerName;
+    private String keycloakSecretToUse;
+    private String clusterInfrastructureToUse;
+    private String customServerImage;
 
     public EntandoAppSpecBuilder() {
         //Needed for JSON Deserialization
 
     }
 
-    @Deprecated
-    @SuppressWarnings("PMD")
-    //Because it is deprecated
-    public EntandoAppSpecBuilder(JeeServer jeeServer, DbmsImageVendor dbms) {
-        withJeeServer(jeeServer);
-        withDbms(dbms);
-    }
-
     public EntandoAppSpecBuilder(EntandoAppSpec spec) {
-        this.keycloakServerNamespace = spec.getKeycloakServerNamespace();
-        this.keycloakServerName = spec.getKeycloakServerName();
+        this.keycloakSecretToUse = spec.getKeycloakSecretToUse().orElse(null);
         this.replicas = spec.getReplicas().orElse(null);
         this.entandoImageVersion = spec.getEntandoImageVersion().orElse(null);
-        this.tlsEnabled = spec.getTlsEnabled().orElse(null);
+        this.tlsSecretName = spec.getTlsSecretName().orElse(null);
         this.dbms = spec.getDbms().orElse(null);
-        this.jeeServer = spec.getJeeServer().orElse(null);
+        this.standardServerImage = spec.getStandardServerImage().orElse(null);
         this.ingressHostName = spec.getIngressHostName().orElse(null);
+        this.clusterInfrastructureToUse = spec.getClusterInfrastructureTouse().orElse(null);
+        this.customServerImage = spec.getCustomServerImage().orElse(null);
     }
 
-    public N withJeeServer(JeeServer jeeServer) {
-        this.jeeServer = jeeServer;
+    public N withStandardServerImage(JeeServer jeeServer) {
+        this.standardServerImage = jeeServer;
+        this.customServerImage = jeeServer == null ? this.customServerImage : null;
+        return (N) this;
+    }
+
+    public N withCustomServerImage(String customServerImage) {
+        this.customServerImage = customServerImage;
+        this.standardServerImage = customServerImage == null ? standardServerImage : null;
         return (N) this;
     }
 
@@ -53,8 +54,8 @@ public class EntandoAppSpecBuilder<N extends EntandoAppSpecBuilder> {
         return (N) this;
     }
 
-    public N withTlsEnabled(Boolean tlsEnabled) {
-        this.tlsEnabled = tlsEnabled;
+    public N withTlsSecretName(String tlsSecretName) {
+        this.tlsSecretName = tlsSecretName;
         return (N) this;
     }
 
@@ -63,9 +64,13 @@ public class EntandoAppSpecBuilder<N extends EntandoAppSpecBuilder> {
         return (N) this;
     }
 
-    public N withKeycloakServer(String namespace, String name) {
-        this.keycloakServerName = name;
-        this.keycloakServerNamespace = namespace;
+    public N withKeycloakSecretToUse(String name) {
+        this.keycloakSecretToUse = name;
+        return (N) this;
+    }
+
+    public N withClusterInfrastructureToUse(String name) {
+        this.clusterInfrastructureToUse = name;
         return (N) this;
     }
 
@@ -75,7 +80,7 @@ public class EntandoAppSpecBuilder<N extends EntandoAppSpecBuilder> {
     }
 
     public EntandoAppSpec build() {
-        return new EntandoAppSpec(this.jeeServer, this.dbms, this.ingressHostName, this.replicas,
-                this.entandoImageVersion, this.tlsEnabled, keycloakServerNamespace, keycloakServerName);
+        return new EntandoAppSpec(this.standardServerImage, this.customServerImage, this.dbms, this.ingressHostName, this.replicas,
+                this.entandoImageVersion, this.tlsSecretName, this.keycloakSecretToUse, this.clusterInfrastructureToUse);
     }
 }

--- a/src/main/java/org/entando/kubernetes/model/externaldatabase/ExternalDatabaseOperationFactory.java
+++ b/src/main/java/org/entando/kubernetes/model/externaldatabase/ExternalDatabaseOperationFactory.java
@@ -1,0 +1,58 @@
+package org.entando.kubernetes.model.externaldatabase;
+
+import static java.lang.Thread.sleep;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.internal.CustomResourceOperationsImpl;
+import java.util.List;
+
+public final class ExternalDatabaseOperationFactory {
+
+    private static final int NOT_FOUND = 404;
+    private static CustomResourceDefinition entandoPluginCrd;
+
+    private ExternalDatabaseOperationFactory() {
+    }
+
+    public static CustomResourceOperationsImpl<ExternalDatabase, ExternalDatabaseList,
+            DoneableExternalDatabase> produceAllExternalDatabases(
+            KubernetesClient client) throws InterruptedException {
+        synchronized (ExternalDatabaseOperationFactory.class) {
+            entandoPluginCrd = client.customResourceDefinitions().withName(ExternalDatabase.CRD_NAME).get();
+            if (entandoPluginCrd == null) {
+                List<HasMetadata> list = client.load(Thread.currentThread().getContextClassLoader()
+                        .getResourceAsStream("crd/ExternalDatabaseCRD.yaml")).get();
+                entandoPluginCrd = (CustomResourceDefinition) list.get(0);
+                // see issue https://github.com/fabric8io/kubernetes-client/issues/1486
+                entandoPluginCrd.getSpec().getValidation().getOpenAPIV3Schema().setDependencies(null);
+                client.customResourceDefinitions().create(entandoPluginCrd);
+            }
+
+        }
+        CustomResourceOperationsImpl<ExternalDatabase, ExternalDatabaseList,
+                DoneableExternalDatabase>
+                oper = (CustomResourceOperationsImpl<ExternalDatabase, ExternalDatabaseList,
+                DoneableExternalDatabase>) client
+                .customResources(entandoPluginCrd, ExternalDatabase.class, ExternalDatabaseList.class,
+                        DoneableExternalDatabase.class);
+        while (notAvailable(oper)) {
+            sleep(100);
+        }
+        return oper;
+    }
+
+    private static boolean notAvailable(
+            CustomResourceOperationsImpl<ExternalDatabase, ExternalDatabaseList,
+                    DoneableExternalDatabase> oper) {
+        try {
+            oper.inNamespace("default").list().getItems().size();
+            return false;
+        } catch (KubernetesClientException e) {
+            return e.getCode() == NOT_FOUND;
+        }
+    }
+
+}

--- a/src/main/java/org/entando/kubernetes/model/infrastructure/DoneableEntandoClusterInfrastructure.java
+++ b/src/main/java/org/entando/kubernetes/model/infrastructure/DoneableEntandoClusterInfrastructure.java
@@ -1,0 +1,42 @@
+package org.entando.kubernetes.model.infrastructure;
+
+import io.fabric8.kubernetes.api.builder.Function;
+import java.util.Optional;
+import org.entando.kubernetes.model.AbstractServerStatus;
+import org.entando.kubernetes.model.DoneableEntandoCustomResource;
+import org.entando.kubernetes.model.EntandoCustomResourceStatus;
+import org.entando.kubernetes.model.EntandoDeploymentPhase;
+
+public class DoneableEntandoClusterInfrastructure extends
+        EntandoClusterInfrastructureFluent<DoneableEntandoClusterInfrastructure> implements
+        DoneableEntandoCustomResource<DoneableEntandoClusterInfrastructure, EntandoClusterInfrastructure> {
+
+    private final Function<EntandoClusterInfrastructure, EntandoClusterInfrastructure> function;
+    private final EntandoCustomResourceStatus status;
+
+    public DoneableEntandoClusterInfrastructure(EntandoClusterInfrastructure resource,
+            Function<EntandoClusterInfrastructure, EntandoClusterInfrastructure> function) {
+        super(resource.getSpec(), resource.getMetadata());
+        this.status = Optional.ofNullable(resource.getStatus()).orElse(new EntandoCustomResourceStatus());
+        this.function = function;
+    }
+
+    @Override
+    public DoneableEntandoClusterInfrastructure withStatus(AbstractServerStatus status) {
+        this.status.putServerStatus(status);
+        return this;
+    }
+
+    @Override
+    public DoneableEntandoClusterInfrastructure withPhase(EntandoDeploymentPhase phase) {
+        status.setEntandoDeploymentPhase(phase);
+        return this;
+    }
+
+    @Override
+    public EntandoClusterInfrastructure done() {
+        EntandoClusterInfrastructure entandoClusterInfrastructure = new EntandoClusterInfrastructure(spec.build(), metadata.build(),
+                status);
+        return function.apply(entandoClusterInfrastructure);
+    }
+}

--- a/src/main/java/org/entando/kubernetes/model/infrastructure/DoneableEntandoClusterInfrastructure.java
+++ b/src/main/java/org/entando/kubernetes/model/infrastructure/DoneableEntandoClusterInfrastructure.java
@@ -35,7 +35,7 @@ public class DoneableEntandoClusterInfrastructure extends
 
     @Override
     public EntandoClusterInfrastructure done() {
-        EntandoClusterInfrastructure entandoClusterInfrastructure = new EntandoClusterInfrastructure(spec.build(), metadata.build(),
+        EntandoClusterInfrastructure entandoClusterInfrastructure = new EntandoClusterInfrastructure(metadata.build(), spec.build(),
                 status);
         return function.apply(entandoClusterInfrastructure);
     }

--- a/src/main/java/org/entando/kubernetes/model/infrastructure/EntandoClusterInfrastructure.java
+++ b/src/main/java/org/entando/kubernetes/model/infrastructure/EntandoClusterInfrastructure.java
@@ -36,7 +36,8 @@ public class EntandoClusterInfrastructure extends CustomResource implements HasI
         this.spec = spec;
     }
 
-    public EntandoClusterInfrastructure(EntandoClusterInfrastructureSpec spec, ObjectMeta metadata, EntandoCustomResourceStatus status) {
+    public EntandoClusterInfrastructure(ObjectMeta metadata, EntandoClusterInfrastructureSpec spec,
+            EntandoCustomResourceStatus status) {
         this(metadata, spec);
         this.entandoStatus = status;
     }

--- a/src/main/java/org/entando/kubernetes/model/infrastructure/EntandoClusterInfrastructure.java
+++ b/src/main/java/org/entando/kubernetes/model/infrastructure/EntandoClusterInfrastructure.java
@@ -1,4 +1,4 @@
-package org.entando.kubernetes.model.keycloakserver;
+package org.entando.kubernetes.model.infrastructure;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
@@ -12,44 +12,45 @@ import java.util.Optional;
 import org.entando.kubernetes.model.EntandoCustomResource;
 import org.entando.kubernetes.model.EntandoCustomResourceStatus;
 import org.entando.kubernetes.model.HasIngress;
+import org.entando.kubernetes.model.RequiresKeycloak;
 
 @JsonSerialize
 @JsonDeserialize
 @JsonInclude(Include.NON_NULL)
 @JsonAutoDetect(fieldVisibility = Visibility.ANY, isGetterVisibility = Visibility.NONE, getterVisibility = Visibility.NONE,
         setterVisibility = Visibility.NONE)
-public class KeycloakServer extends CustomResource implements HasIngress, EntandoCustomResource {
+public class EntandoClusterInfrastructure extends CustomResource implements HasIngress, EntandoCustomResource, RequiresKeycloak {
 
-    public static final String CRD_NAME = "entandokeycloakservers.entando.org";
+    public static final String CRD_NAME = "entandoclusterinfrastructures.entando.org";
 
-    private KeycloakServerSpec spec;
+    private EntandoClusterInfrastructureSpec spec;
     private EntandoCustomResourceStatus entandoStatus;
 
-    public KeycloakServer() {
-        super("EntandoKeycloakServer");
+    public EntandoClusterInfrastructure() {
+        super();
         setApiVersion("entando.org/v1alpha1");
     }
 
-    public KeycloakServer(KeycloakServerSpec spec) {
+    public EntandoClusterInfrastructure(EntandoClusterInfrastructureSpec spec) {
         this();
         this.spec = spec;
     }
 
-    public KeycloakServer(KeycloakServerSpec spec, ObjectMeta metadata, EntandoCustomResourceStatus status) {
+    public EntandoClusterInfrastructure(EntandoClusterInfrastructureSpec spec, ObjectMeta metadata, EntandoCustomResourceStatus status) {
         this(metadata, spec);
         this.entandoStatus = status;
     }
 
-    public KeycloakServer(ObjectMeta metadata, KeycloakServerSpec spec) {
+    public EntandoClusterInfrastructure(ObjectMeta metadata, EntandoClusterInfrastructureSpec spec) {
         this(spec);
         super.setMetadata(metadata);
     }
 
-    public KeycloakServerSpec getSpec() {
+    public EntandoClusterInfrastructureSpec getSpec() {
         return spec;
     }
 
-    public void setSpec(KeycloakServerSpec spec) {
+    public void setSpec(EntandoClusterInfrastructureSpec spec) {
         this.spec = spec;
     }
 
@@ -71,5 +72,10 @@ public class KeycloakServer extends CustomResource implements HasIngress, Entand
     @Override
     public Optional<String> getTlsSecretName() {
         return getSpec().getTlsSecretName();
+    }
+
+    @Override
+    public Optional<String> getKeycloakSecretToUse() {
+        return spec.getKeycloakSecretToUse();
     }
 }

--- a/src/main/java/org/entando/kubernetes/model/infrastructure/EntandoClusterInfrastructureBuilder.java
+++ b/src/main/java/org/entando/kubernetes/model/infrastructure/EntandoClusterInfrastructureBuilder.java
@@ -1,0 +1,12 @@
+package org.entando.kubernetes.model.infrastructure;
+
+import io.fabric8.kubernetes.api.builder.Builder;
+
+public class EntandoClusterInfrastructureBuilder extends EntandoClusterInfrastructureFluent<EntandoClusterInfrastructureBuilder>
+        implements Builder<EntandoClusterInfrastructure> {
+
+    @Override
+    public EntandoClusterInfrastructure build() {
+        return new EntandoClusterInfrastructure(super.metadata.build(), super.spec.build());
+    }
+}

--- a/src/main/java/org/entando/kubernetes/model/infrastructure/EntandoClusterInfrastructureFluent.java
+++ b/src/main/java/org/entando/kubernetes/model/infrastructure/EntandoClusterInfrastructureFluent.java
@@ -1,0 +1,109 @@
+package org.entando.kubernetes.model.infrastructure;
+
+import io.fabric8.kubernetes.api.builder.BaseFluent;
+import io.fabric8.kubernetes.api.builder.Fluent;
+import io.fabric8.kubernetes.api.builder.Nested;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMetaFluentImpl;
+
+public class EntandoClusterInfrastructureFluent<A extends EntandoClusterInfrastructureFluent<A>> extends BaseFluent<A> implements
+        Fluent<A> {
+
+    protected ObjectMetaBuilder metadata;
+    protected EntandoClusterInfrastructureSpecBuilder spec;
+
+    protected EntandoClusterInfrastructureFluent() {
+        super();
+        this.metadata = new ObjectMetaBuilder();
+        this.spec = new EntandoClusterInfrastructureSpecBuilder();
+    }
+
+    protected EntandoClusterInfrastructureFluent(EntandoClusterInfrastructureSpec spec, ObjectMeta objectMeta) {
+        super();
+        this.metadata = new ObjectMetaBuilder(objectMeta);
+        this.spec = new EntandoClusterInfrastructureSpecBuilder(spec);
+    }
+
+    public MetadataNestedImpl<A> editMetadata() {
+        return new MetadataNestedImpl<A>((A) this, this.metadata.build());
+    }
+
+    public MetadataNestedImpl<A> withNewMetadata() {
+        return new MetadataNestedImpl<A>((A) this);
+    }
+
+    public A withMetadata(ObjectMeta metadata) {
+        this.metadata = new ObjectMetaBuilder(metadata);
+        return (A) this;
+    }
+
+    public SpecNestedImplCluster<A> editSpec() {
+        return new SpecNestedImplCluster<>((A) this, this.spec.build());
+    }
+
+    public SpecNestedImplCluster<A> withNewSpec() {
+        return new SpecNestedImplCluster<>((A) this);
+    }
+
+    public A withSpec(EntandoClusterInfrastructureSpec spec) {
+        this.spec = new EntandoClusterInfrastructureSpecBuilder(spec);
+        return (A) this;
+    }
+
+    public static class SpecNestedImplCluster<N extends EntandoClusterInfrastructureFluent> extends
+            EntandoClusterInfrastructureSpecBuilder<SpecNestedImplCluster<N>> implements
+            Nested<N> {
+
+        private final N parentBuilder;
+
+        SpecNestedImplCluster(N parentBuilder, EntandoClusterInfrastructureSpec item) {
+            super(item);
+            this.parentBuilder = parentBuilder;
+        }
+
+        public SpecNestedImplCluster(N parentBuilder) {
+            super();
+            this.parentBuilder = parentBuilder;
+        }
+
+        @Override
+        public N and() {
+            return (N) parentBuilder.withSpec(this.build());
+        }
+
+        public N endSpec() {
+            return this.and();
+        }
+    }
+
+    public static class MetadataNestedImpl<N extends EntandoClusterInfrastructureFluent<N>> extends
+            ObjectMetaFluentImpl<EntandoClusterInfrastructureFluent.MetadataNestedImpl<N>> implements
+            Nested<N> {
+
+        private final N parentBuilder;
+        private final ObjectMetaBuilder builder;
+
+        MetadataNestedImpl(N parentBuilder, ObjectMeta item) {
+            super();
+            this.parentBuilder = parentBuilder;
+            this.builder = new ObjectMetaBuilder(this, item);
+        }
+
+        MetadataNestedImpl(N parentBuilder) {
+            super();
+            this.parentBuilder = parentBuilder;
+            this.builder = new ObjectMetaBuilder(this);
+        }
+
+        @Override
+        public N and() {
+            return parentBuilder.withMetadata(this.builder.build());
+        }
+
+        public N endMetadata() {
+            return this.and();
+        }
+    }
+
+}

--- a/src/main/java/org/entando/kubernetes/model/infrastructure/EntandoClusterInfrastructureList.java
+++ b/src/main/java/org/entando/kubernetes/model/infrastructure/EntandoClusterInfrastructureList.java
@@ -1,0 +1,9 @@
+package org.entando.kubernetes.model.infrastructure;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.client.CustomResourceList;
+
+@JsonDeserialize
+public class EntandoClusterInfrastructureList extends CustomResourceList<EntandoClusterInfrastructure> {
+
+}

--- a/src/main/java/org/entando/kubernetes/model/infrastructure/EntandoClusterInfrastructureOperationFactory.java
+++ b/src/main/java/org/entando/kubernetes/model/infrastructure/EntandoClusterInfrastructureOperationFactory.java
@@ -1,0 +1,58 @@
+package org.entando.kubernetes.model.infrastructure;
+
+import static java.lang.Thread.sleep;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.internal.CustomResourceOperationsImpl;
+import java.util.List;
+
+public final class EntandoClusterInfrastructureOperationFactory {
+
+    private static final int NOT_FOUND = 404;
+    private static CustomResourceDefinition entandoInfrastructureCrd;
+
+    private EntandoClusterInfrastructureOperationFactory() {
+    }
+
+    public static CustomResourceOperationsImpl<EntandoClusterInfrastructure, EntandoClusterInfrastructureList,
+            DoneableEntandoClusterInfrastructure> produceAllEntandoClusterInfrastructures(
+            KubernetesClient client) throws InterruptedException {
+        synchronized (EntandoClusterInfrastructureOperationFactory.class) {
+            entandoInfrastructureCrd = client.customResourceDefinitions().withName(EntandoClusterInfrastructure.CRD_NAME).get();
+            if (entandoInfrastructureCrd == null) {
+                List<HasMetadata> list = client.load(Thread.currentThread().getContextClassLoader()
+                        .getResourceAsStream("crd/EntandoClusterInfrastructureCRD.yaml")).get();
+                entandoInfrastructureCrd = (CustomResourceDefinition) list.get(0);
+                // see issue https://github.com/fabric8io/kubernetes-client/issues/1486
+                entandoInfrastructureCrd.getSpec().getValidation().getOpenAPIV3Schema().setDependencies(null);
+                client.customResourceDefinitions().create(entandoInfrastructureCrd);
+            }
+
+        }
+        CustomResourceOperationsImpl<EntandoClusterInfrastructure, EntandoClusterInfrastructureList,
+                DoneableEntandoClusterInfrastructure>
+                oper = (CustomResourceOperationsImpl<EntandoClusterInfrastructure, EntandoClusterInfrastructureList,
+                DoneableEntandoClusterInfrastructure>) client
+                .customResources(entandoInfrastructureCrd, EntandoClusterInfrastructure.class, EntandoClusterInfrastructureList.class,
+                        DoneableEntandoClusterInfrastructure.class);
+        while (notAvailable(oper)) {
+            sleep(100);
+        }
+        return oper;
+    }
+
+    private static boolean notAvailable(
+            CustomResourceOperationsImpl<EntandoClusterInfrastructure, EntandoClusterInfrastructureList,
+                    DoneableEntandoClusterInfrastructure> oper) {
+        try {
+            oper.inNamespace("default").list().getItems().size();
+            return false;
+        } catch (KubernetesClientException e) {
+            return e.getCode() == NOT_FOUND;
+        }
+    }
+
+}

--- a/src/main/java/org/entando/kubernetes/model/infrastructure/EntandoClusterInfrastructureSpec.java
+++ b/src/main/java/org/entando/kubernetes/model/infrastructure/EntandoClusterInfrastructureSpec.java
@@ -1,4 +1,4 @@
-package org.entando.kubernetes.model.keycloakserver;
+package org.entando.kubernetes.model.infrastructure;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
@@ -9,46 +9,42 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.Optional;
 import org.entando.kubernetes.model.DbmsImageVendor;
 import org.entando.kubernetes.model.HasIngress;
+import org.entando.kubernetes.model.RequiresKeycloak;
 
 @JsonInclude(Include.NON_NULL)
 @JsonSerialize
 @JsonDeserialize
 @JsonAutoDetect(fieldVisibility = Visibility.ANY, isGetterVisibility = Visibility.NONE, getterVisibility = Visibility.NONE,
         setterVisibility = Visibility.NONE)
-public class KeycloakServerSpec implements HasIngress {
+public class EntandoClusterInfrastructureSpec implements RequiresKeycloak, HasIngress {
 
-    private String imageName;
     private DbmsImageVendor dbms;
     private String ingressHostName;
     private String entandoImageVersion;
     private String tlsSecretName;
+    private String keycloakSecretToUse;
     private Integer replicas = 1;
     @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
     //because 'default' is a reserved word
     private boolean isDefault;
 
-    public KeycloakServerSpec() {
+    public EntandoClusterInfrastructureSpec() {
         super();
     }
 
-    public KeycloakServerSpec(String imageName, DbmsImageVendor dbms, String ingressHostName,
-            String entandoImageVersion, String tlsSecretName) {
-        this.imageName = imageName;
+    public EntandoClusterInfrastructureSpec(DbmsImageVendor dbms, String ingressHostName, String entandoImageVersion,
+            String tlsSecretName, Integer replicas, String keycloakSecretToUse, boolean isDefault) {
         this.dbms = dbms;
         this.ingressHostName = ingressHostName;
         this.entandoImageVersion = entandoImageVersion;
         this.tlsSecretName = tlsSecretName;
-    }
-
-    public KeycloakServerSpec(String imageName, DbmsImageVendor dbms, String ingressHostName, String entandoImageVersion,
-            String tlsSecretName, int replicas, boolean isDefault) {
-        this(imageName, dbms, ingressHostName, entandoImageVersion, tlsSecretName);
+        this.keycloakSecretToUse = keycloakSecretToUse;
         this.replicas = replicas;
         this.isDefault = isDefault;
     }
 
-    public Optional<String> getImageName() {
-        return Optional.ofNullable(imageName);
+    public boolean isDefault() {
+        return isDefault;
     }
 
     public Optional<DbmsImageVendor> getDbms() {
@@ -77,7 +73,8 @@ public class KeycloakServerSpec implements HasIngress {
         this.replicas = replicas;
     }
 
-    public boolean isDefault() {
-        return isDefault;
+    @Override
+    public Optional<String> getKeycloakSecretToUse() {
+        return Optional.ofNullable(keycloakSecretToUse);
     }
 }

--- a/src/main/java/org/entando/kubernetes/model/infrastructure/EntandoClusterInfrastructureSpecBuilder.java
+++ b/src/main/java/org/entando/kubernetes/model/infrastructure/EntandoClusterInfrastructureSpecBuilder.java
@@ -1,38 +1,38 @@
-package org.entando.kubernetes.model.keycloakserver;
+package org.entando.kubernetes.model.infrastructure;
 
 import org.entando.kubernetes.model.DbmsImageVendor;
 
-public class KeycloakServerSpecBuilder<N extends KeycloakServerSpecBuilder> {
+public class EntandoClusterInfrastructureSpecBuilder<N extends EntandoClusterInfrastructureSpecBuilder> {
 
-    private String imageName;
     private DbmsImageVendor dbms;
     private String ingressHostName;
     private String entandoImageVersion;
     private String tlsSecretName;
     private int replicas = 1;
+    private String keycloakSecretToUse;
     private boolean isDefault;
 
-    public KeycloakServerSpecBuilder(KeycloakServerSpec spec) {
-        this.imageName = spec.getImageName().orElse(null);
+    public EntandoClusterInfrastructureSpecBuilder(EntandoClusterInfrastructureSpec spec) {
         this.dbms = spec.getDbms().orElse(null);
         this.ingressHostName = spec.getIngressHostName().orElse(null);
         this.entandoImageVersion = spec.getEntandoImageVersion().orElse(null);
         this.tlsSecretName = spec.getTlsSecretName().orElse(null);
         this.replicas = spec.getReplicas();
+        this.keycloakSecretToUse = spec.getKeycloakSecretToUse().orElse(null);
         this.isDefault = spec.isDefault();
     }
 
-    public KeycloakServerSpecBuilder() {
+    public EntandoClusterInfrastructureSpecBuilder() {
         //required default constructor
+    }
+
+    public N withKeycloakSecretToUse(String keycloakSecretToUse) {
+        this.keycloakSecretToUse = keycloakSecretToUse;
+        return (N) this;
     }
 
     public N withDefault(boolean isDefault) {
         this.isDefault = isDefault;
-        return (N) this;
-    }
-
-    public N withImageName(String imageName) {
-        this.imageName = imageName;
         return (N) this;
     }
 
@@ -61,8 +61,9 @@ public class KeycloakServerSpecBuilder<N extends KeycloakServerSpecBuilder> {
         return (N) this;
     }
 
-    public KeycloakServerSpec build() {
-        return new KeycloakServerSpec(imageName, dbms, ingressHostName, entandoImageVersion, tlsSecretName, replicas, isDefault);
+    public EntandoClusterInfrastructureSpec build() {
+        return new EntandoClusterInfrastructureSpec(dbms, ingressHostName, entandoImageVersion, tlsSecretName, replicas,
+                keycloakSecretToUse, isDefault);
     }
 
 }

--- a/src/main/java/org/entando/kubernetes/model/keycloakserver/DoneableKeycloakServer.java
+++ b/src/main/java/org/entando/kubernetes/model/keycloakserver/DoneableKeycloakServer.java
@@ -33,7 +33,7 @@ public class DoneableKeycloakServer extends KeycloakServerFluent<DoneableKeycloa
 
     @Override
     public KeycloakServer done() {
-        KeycloakServer keycloakServer = new KeycloakServer(spec.build(), metadata.build(), status);
+        KeycloakServer keycloakServer = new KeycloakServer(metadata.build(), spec.build(), status);
         return function.apply(keycloakServer);
     }
 }

--- a/src/main/java/org/entando/kubernetes/model/keycloakserver/KeycloakServer.java
+++ b/src/main/java/org/entando/kubernetes/model/keycloakserver/KeycloakServer.java
@@ -35,7 +35,7 @@ public class KeycloakServer extends CustomResource implements HasIngress, Entand
         this.spec = spec;
     }
 
-    public KeycloakServer(KeycloakServerSpec spec, ObjectMeta metadata, EntandoCustomResourceStatus status) {
+    public KeycloakServer(ObjectMeta metadata, KeycloakServerSpec spec, EntandoCustomResourceStatus status) {
         this(metadata, spec);
         this.entandoStatus = status;
     }

--- a/src/main/java/org/entando/kubernetes/model/keycloakserver/KeycloakServerOperationFactory.java
+++ b/src/main/java/org/entando/kubernetes/model/keycloakserver/KeycloakServerOperationFactory.java
@@ -1,0 +1,58 @@
+package org.entando.kubernetes.model.keycloakserver;
+
+import static java.lang.Thread.sleep;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.internal.CustomResourceOperationsImpl;
+import java.util.List;
+
+public final class KeycloakServerOperationFactory {
+
+    private static final int NOT_FOUND = 404;
+    private static CustomResourceDefinition entandoPluginCrd;
+
+    private KeycloakServerOperationFactory() {
+    }
+
+    public static CustomResourceOperationsImpl<KeycloakServer, KeycloakServerList,
+            DoneableKeycloakServer> produceAllKeycloakServers(
+            KubernetesClient client) throws InterruptedException {
+        synchronized (KeycloakServerOperationFactory.class) {
+            entandoPluginCrd = client.customResourceDefinitions().withName(KeycloakServer.CRD_NAME).get();
+            if (entandoPluginCrd == null) {
+                List<HasMetadata> list = client.load(Thread.currentThread().getContextClassLoader()
+                        .getResourceAsStream("crd/EntandoKeycloakServerCRD.yaml")).get();
+                entandoPluginCrd = (CustomResourceDefinition) list.get(0);
+                // see issue https://github.com/fabric8io/kubernetes-client/issues/1486
+                entandoPluginCrd.getSpec().getValidation().getOpenAPIV3Schema().setDependencies(null);
+                client.customResourceDefinitions().create(entandoPluginCrd);
+            }
+
+        }
+        CustomResourceOperationsImpl<KeycloakServer, KeycloakServerList,
+                DoneableKeycloakServer>
+                oper = (CustomResourceOperationsImpl<KeycloakServer, KeycloakServerList,
+                DoneableKeycloakServer>) client
+                .customResources(entandoPluginCrd, KeycloakServer.class, KeycloakServerList.class,
+                        DoneableKeycloakServer.class);
+        while (notAvailable(oper)) {
+            sleep(100);
+        }
+        return oper;
+    }
+
+    private static boolean notAvailable(
+            CustomResourceOperationsImpl<KeycloakServer, KeycloakServerList,
+                    DoneableKeycloakServer> oper) {
+        try {
+            oper.inNamespace("default").list().getItems().size();
+            return false;
+        } catch (KubernetesClientException e) {
+            return e.getCode() == NOT_FOUND;
+        }
+    }
+
+}

--- a/src/main/java/org/entando/kubernetes/model/link/DoneableEntandoAppPluginLink.java
+++ b/src/main/java/org/entando/kubernetes/model/link/DoneableEntandoAppPluginLink.java
@@ -33,7 +33,7 @@ public class DoneableEntandoAppPluginLink extends EntandoAppPluginLinkFluent<Don
 
     @Override
     public EntandoAppPluginLink done() {
-        return function.apply(new EntandoAppPluginLink(spec.build(), metadata.build(), entandoStatus));
+        return function.apply(new EntandoAppPluginLink(metadata.build(), spec.build(), entandoStatus));
     }
 
 }

--- a/src/main/java/org/entando/kubernetes/model/link/DoneableEntandoAppPluginLink.java
+++ b/src/main/java/org/entando/kubernetes/model/link/DoneableEntandoAppPluginLink.java
@@ -1,0 +1,39 @@
+package org.entando.kubernetes.model.link;
+
+import io.fabric8.kubernetes.api.builder.Function;
+import java.util.Optional;
+import org.entando.kubernetes.model.AbstractServerStatus;
+import org.entando.kubernetes.model.DoneableEntandoCustomResource;
+import org.entando.kubernetes.model.EntandoCustomResourceStatus;
+import org.entando.kubernetes.model.EntandoDeploymentPhase;
+
+public class DoneableEntandoAppPluginLink extends EntandoAppPluginLinkFluent<DoneableEntandoAppPluginLink> implements
+        DoneableEntandoCustomResource<DoneableEntandoAppPluginLink, EntandoAppPluginLink> {
+
+    private final EntandoCustomResourceStatus entandoStatus;
+    private final Function<EntandoAppPluginLink, EntandoAppPluginLink> function;
+
+    public DoneableEntandoAppPluginLink(EntandoAppPluginLink resource, Function<EntandoAppPluginLink, EntandoAppPluginLink> function) {
+        super(resource.getSpec(), resource.getMetadata());
+        this.function = function;
+        this.entandoStatus = Optional.ofNullable(resource.getStatus()).orElse(new EntandoCustomResourceStatus());
+    }
+
+    @Override
+    public DoneableEntandoAppPluginLink withStatus(AbstractServerStatus status) {
+        this.entandoStatus.putServerStatus(status);
+        return this;
+    }
+
+    @Override
+    public DoneableEntandoAppPluginLink withPhase(EntandoDeploymentPhase phase) {
+        entandoStatus.setEntandoDeploymentPhase(phase);
+        return this;
+    }
+
+    @Override
+    public EntandoAppPluginLink done() {
+        return function.apply(new EntandoAppPluginLink(spec.build(), metadata.build(), entandoStatus));
+    }
+
+}

--- a/src/main/java/org/entando/kubernetes/model/link/EntandoAppPluginLink.java
+++ b/src/main/java/org/entando/kubernetes/model/link/EntandoAppPluginLink.java
@@ -32,7 +32,7 @@ public class EntandoAppPluginLink extends CustomResource implements EntandoCusto
         this.spec = spec;
     }
 
-    public EntandoAppPluginLink(EntandoAppPluginLinkSpec spec, ObjectMeta meta, EntandoCustomResourceStatus entandoStatus) {
+    public EntandoAppPluginLink(ObjectMeta meta, EntandoAppPluginLinkSpec spec, EntandoCustomResourceStatus entandoStatus) {
         this(spec, meta);
         this.entandoStatus = entandoStatus;
     }

--- a/src/main/java/org/entando/kubernetes/model/link/EntandoAppPluginLink.java
+++ b/src/main/java/org/entando/kubernetes/model/link/EntandoAppPluginLink.java
@@ -1,0 +1,58 @@
+package org.entando.kubernetes.model.link;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.client.CustomResource;
+import org.entando.kubernetes.model.EntandoCustomResource;
+import org.entando.kubernetes.model.EntandoCustomResourceStatus;
+
+@JsonSerialize
+@JsonDeserialize
+@JsonInclude(Include.NON_NULL)
+@JsonAutoDetect(fieldVisibility = Visibility.ANY, isGetterVisibility = Visibility.NONE, getterVisibility = Visibility.NONE,
+        setterVisibility = Visibility.NONE)
+public class EntandoAppPluginLink extends CustomResource implements EntandoCustomResource {
+
+    public static final String CRD_NAME = "entandoapppluginlinks.entando.org";
+    private EntandoCustomResourceStatus entandoStatus;
+    private EntandoAppPluginLinkSpec spec;
+
+    public EntandoAppPluginLink() {
+        super();
+        setApiVersion("entando.org/v1alpha1");
+    }
+
+    public EntandoAppPluginLink(EntandoAppPluginLinkSpec spec) {
+        this();
+        this.spec = spec;
+    }
+
+    public EntandoAppPluginLink(EntandoAppPluginLinkSpec spec, ObjectMeta meta, EntandoCustomResourceStatus entandoStatus) {
+        this(spec, meta);
+        this.entandoStatus = entandoStatus;
+    }
+
+    public EntandoAppPluginLink(EntandoAppPluginLinkSpec spec, ObjectMeta meta) {
+        this(spec);
+        super.setMetadata(meta);
+    }
+
+    public EntandoAppPluginLinkSpec getSpec() {
+        return spec;
+    }
+
+    @Override
+    public EntandoCustomResourceStatus getStatus() {
+        return entandoStatus;
+    }
+
+    @Override
+    public void setStatus(EntandoCustomResourceStatus status) {
+        this.entandoStatus = status;
+    }
+}

--- a/src/main/java/org/entando/kubernetes/model/link/EntandoAppPluginLink.java
+++ b/src/main/java/org/entando/kubernetes/model/link/EntandoAppPluginLink.java
@@ -33,11 +33,11 @@ public class EntandoAppPluginLink extends CustomResource implements EntandoCusto
     }
 
     public EntandoAppPluginLink(ObjectMeta meta, EntandoAppPluginLinkSpec spec, EntandoCustomResourceStatus entandoStatus) {
-        this(spec, meta);
+        this(meta, spec);
         this.entandoStatus = entandoStatus;
     }
 
-    public EntandoAppPluginLink(EntandoAppPluginLinkSpec spec, ObjectMeta meta) {
+    public EntandoAppPluginLink(ObjectMeta meta, EntandoAppPluginLinkSpec spec) {
         this(spec);
         super.setMetadata(meta);
     }

--- a/src/main/java/org/entando/kubernetes/model/link/EntandoAppPluginLinkBuilder.java
+++ b/src/main/java/org/entando/kubernetes/model/link/EntandoAppPluginLinkBuilder.java
@@ -1,0 +1,9 @@
+package org.entando.kubernetes.model.link;
+
+public class EntandoAppPluginLinkBuilder extends EntandoAppPluginLinkFluent<EntandoAppPluginLinkBuilder> {
+
+    public EntandoAppPluginLink build() {
+        return new EntandoAppPluginLink(super.spec.build(), super.metadata.build());
+    }
+
+}

--- a/src/main/java/org/entando/kubernetes/model/link/EntandoAppPluginLinkBuilder.java
+++ b/src/main/java/org/entando/kubernetes/model/link/EntandoAppPluginLinkBuilder.java
@@ -3,7 +3,7 @@ package org.entando.kubernetes.model.link;
 public class EntandoAppPluginLinkBuilder extends EntandoAppPluginLinkFluent<EntandoAppPluginLinkBuilder> {
 
     public EntandoAppPluginLink build() {
-        return new EntandoAppPluginLink(super.spec.build(), super.metadata.build());
+        return new EntandoAppPluginLink(super.metadata.build(), super.spec.build());
     }
 
 }

--- a/src/main/java/org/entando/kubernetes/model/link/EntandoAppPluginLinkFluent.java
+++ b/src/main/java/org/entando/kubernetes/model/link/EntandoAppPluginLinkFluent.java
@@ -1,0 +1,108 @@
+package org.entando.kubernetes.model.link;
+
+import io.fabric8.kubernetes.api.builder.BaseFluent;
+import io.fabric8.kubernetes.api.builder.Fluent;
+import io.fabric8.kubernetes.api.builder.Nested;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMetaFluentImpl;
+
+public class EntandoAppPluginLinkFluent<A extends EntandoAppPluginLinkFluent<A>> extends BaseFluent<A> implements Fluent<A> {
+
+    protected ObjectMetaBuilder metadata;
+    protected EntandoAppPluginLinkSpecBuilder spec;
+
+    protected EntandoAppPluginLinkFluent() {
+        super();
+        this.metadata = new ObjectMetaBuilder();
+        this.spec = new EntandoAppPluginLinkSpecBuilder();
+    }
+
+    protected EntandoAppPluginLinkFluent(EntandoAppPluginLinkSpec spec, ObjectMeta objectMeta) {
+        super();
+        this.metadata = new ObjectMetaBuilder(objectMeta);
+        this.spec = new EntandoAppPluginLinkSpecBuilder(spec);
+    }
+
+    public MetadataNestedImpl<A> editMetadata() {
+        return new MetadataNestedImpl<A>((A) this, this.metadata.build());
+    }
+
+    public MetadataNestedImpl<A> withNewMetadata() {
+        return new MetadataNestedImpl<A>((A) this);
+    }
+
+    public A withMetadata(ObjectMeta metadata) {
+        this.metadata = new ObjectMetaBuilder(metadata);
+        return (A) this;
+    }
+
+    public SpecNestedImpl<A> editSpec() {
+        return new SpecNestedImpl<A>((A) this, this.spec.build());
+    }
+
+    public SpecNestedImpl<A> withNewSpec() {
+        return new SpecNestedImpl<A>((A) this);
+    }
+
+    public A withSpec(EntandoAppPluginLinkSpec spec) {
+        this.spec = new EntandoAppPluginLinkSpecBuilder(spec);
+        return (A) this;
+    }
+
+    public static class SpecNestedImpl<N extends EntandoAppPluginLinkFluent> extends
+            EntandoAppPluginLinkSpecBuilder<SpecNestedImpl<N>> implements
+            Nested<N> {
+
+        private final N parentBuilder;
+
+        SpecNestedImpl(N parentBuilder, EntandoAppPluginLinkSpec item) {
+            super(item);
+            this.parentBuilder = parentBuilder;
+        }
+
+        public SpecNestedImpl(N parentBuilder) {
+            super();
+            this.parentBuilder = parentBuilder;
+        }
+
+        @Override
+        public N and() {
+            return (N) parentBuilder.withSpec(this.build());
+        }
+
+        public N endSpec() {
+            return this.and();
+        }
+    }
+
+    public static class MetadataNestedImpl<N extends EntandoAppPluginLinkFluent<N>> extends
+            ObjectMetaFluentImpl<MetadataNestedImpl<N>> implements
+            Nested<N> {
+
+        private final N parentBuilder;
+        private final ObjectMetaBuilder builder;
+
+        MetadataNestedImpl(N parentBuilder, ObjectMeta item) {
+            super();
+            this.parentBuilder = parentBuilder;
+            this.builder = new ObjectMetaBuilder(this, item);
+        }
+
+        MetadataNestedImpl(N parentBuilder) {
+            super();
+            this.parentBuilder = parentBuilder;
+            this.builder = new ObjectMetaBuilder(this);
+        }
+
+        @Override
+        public N and() {
+            return parentBuilder.withMetadata(this.builder.build());
+        }
+
+        public N endMetadata() {
+            return this.and();
+        }
+    }
+
+}

--- a/src/main/java/org/entando/kubernetes/model/link/EntandoAppPluginLinkList.java
+++ b/src/main/java/org/entando/kubernetes/model/link/EntandoAppPluginLinkList.java
@@ -1,0 +1,7 @@
+package org.entando.kubernetes.model.link;
+
+import io.fabric8.kubernetes.client.CustomResourceList;
+
+public class EntandoAppPluginLinkList extends CustomResourceList<EntandoAppPluginLink> {
+
+}

--- a/src/main/java/org/entando/kubernetes/model/link/EntandoAppPluginLinkOperationFactory.java
+++ b/src/main/java/org/entando/kubernetes/model/link/EntandoAppPluginLinkOperationFactory.java
@@ -1,0 +1,58 @@
+package org.entando.kubernetes.model.link;
+
+import static java.lang.Thread.sleep;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.internal.CustomResourceOperationsImpl;
+import java.util.List;
+
+public final class EntandoAppPluginLinkOperationFactory {
+
+    private static final int NOT_FOUND = 404;
+    private static CustomResourceDefinition EntandoAppPluginLinkCrd;
+
+    private EntandoAppPluginLinkOperationFactory() {
+    }
+
+    public static CustomResourceOperationsImpl<EntandoAppPluginLink, EntandoAppPluginLinkList,
+            DoneableEntandoAppPluginLink> produceAllEntandoAppPluginLinks(
+            KubernetesClient client) throws InterruptedException {
+        synchronized (EntandoAppPluginLinkOperationFactory.class) {
+            EntandoAppPluginLinkCrd = client.customResourceDefinitions().withName(EntandoAppPluginLink.CRD_NAME).get();
+            if (EntandoAppPluginLinkCrd == null) {
+                List<HasMetadata> list = client.load(Thread.currentThread().getContextClassLoader()
+                        .getResourceAsStream("crd/EntandoAppPluginLinkCRD.yaml")).get();
+                EntandoAppPluginLinkCrd = (CustomResourceDefinition) list.get(0);
+                // see issue https://github.com/fabric8io/kubernetes-client/issues/1486
+                EntandoAppPluginLinkCrd.getSpec().getValidation().getOpenAPIV3Schema().setDependencies(null);
+                client.customResourceDefinitions().create(EntandoAppPluginLinkCrd);
+            }
+
+        }
+        CustomResourceOperationsImpl<EntandoAppPluginLink, EntandoAppPluginLinkList,
+                DoneableEntandoAppPluginLink>
+                oper = (CustomResourceOperationsImpl<EntandoAppPluginLink, EntandoAppPluginLinkList,
+                DoneableEntandoAppPluginLink>) client
+                .customResources(EntandoAppPluginLinkCrd, EntandoAppPluginLink.class, EntandoAppPluginLinkList.class,
+                        DoneableEntandoAppPluginLink.class);
+        while (notAvailable(oper)) {
+            sleep(100);
+        }
+        return oper;
+    }
+
+    private static boolean notAvailable(
+            CustomResourceOperationsImpl<EntandoAppPluginLink, EntandoAppPluginLinkList,
+                    DoneableEntandoAppPluginLink> oper) {
+        try {
+            oper.inNamespace("default").list().getItems().size();
+            return false;
+        } catch (KubernetesClientException e) {
+            return e.getCode() == NOT_FOUND;
+        }
+    }
+
+}

--- a/src/main/java/org/entando/kubernetes/model/link/EntandoAppPluginLinkSpec.java
+++ b/src/main/java/org/entando/kubernetes/model/link/EntandoAppPluginLinkSpec.java
@@ -1,0 +1,50 @@
+package org.entando.kubernetes.model.link;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+
+@JsonSerialize
+@JsonDeserialize
+@JsonInclude(Include.NON_NULL)
+@JsonAutoDetect(fieldVisibility = Visibility.ANY, isGetterVisibility = Visibility.NONE, getterVisibility = Visibility.NONE,
+        setterVisibility = Visibility.NONE)
+public class EntandoAppPluginLinkSpec implements KubernetesResource {
+
+    private String entandoAppNamespace;
+    private String entandoAppName;
+    private String entandoPluginNamespace;
+    private String entandoPluginName;
+
+    public EntandoAppPluginLinkSpec() {
+    }
+
+    public EntandoAppPluginLinkSpec(String entandoAppNamespace, String entandoAppName, String entandoPluginNamespace,
+            String entandoPluginName) {
+        this.entandoAppNamespace = entandoAppNamespace;
+        this.entandoAppName = entandoAppName;
+        this.entandoPluginNamespace = entandoPluginNamespace;
+        this.entandoPluginName = entandoPluginName;
+    }
+
+    public String getEntandoAppName() {
+        return entandoAppName;
+    }
+
+    public String getEntandoAppNamespace() {
+        return entandoAppNamespace;
+    }
+
+    public String getEntandoPluginName() {
+        return entandoPluginName;
+    }
+
+    public String getEntandoPluginNamespace() {
+        return entandoPluginNamespace;
+    }
+
+}

--- a/src/main/java/org/entando/kubernetes/model/link/EntandoAppPluginLinkSpecBuilder.java
+++ b/src/main/java/org/entando/kubernetes/model/link/EntandoAppPluginLinkSpecBuilder.java
@@ -1,0 +1,35 @@
+package org.entando.kubernetes.model.link;
+
+public class EntandoAppPluginLinkSpecBuilder<N extends EntandoAppPluginLinkSpecBuilder> {
+
+    private String entandoAppName;
+    private String entandoAppNamespace;
+    private String entandoPluginName;
+    private String entandoPluginNamespace;
+
+    public EntandoAppPluginLinkSpecBuilder() {
+    }
+
+    public EntandoAppPluginLinkSpecBuilder(EntandoAppPluginLinkSpec spec) {
+        this.entandoAppNamespace = spec.getEntandoAppNamespace();
+        this.entandoAppName = spec.getEntandoAppName();
+        this.entandoPluginNamespace = spec.getEntandoPluginNamespace();
+        this.entandoPluginName = spec.getEntandoPluginName();
+    }
+
+    public N withEntandoApp(String entandoAppNamespace, String entandoAppName) {
+        this.entandoAppNamespace = entandoAppNamespace;
+        this.entandoAppName = entandoAppName;
+        return (N) this;
+    }
+
+    public N withEntandoPlugin(String entandoPluginNamespace, String entandoPluginName) {
+        this.entandoPluginNamespace = entandoPluginNamespace;
+        this.entandoPluginName = entandoPluginName;
+        return (N) this;
+    }
+
+    public EntandoAppPluginLinkSpec build() {
+        return new EntandoAppPluginLinkSpec(entandoAppNamespace, entandoAppName, entandoPluginNamespace, entandoPluginName);
+    }
+}

--- a/src/main/java/org/entando/kubernetes/model/plugin/DoneableEntandoPlugin.java
+++ b/src/main/java/org/entando/kubernetes/model/plugin/DoneableEntandoPlugin.java
@@ -33,6 +33,6 @@ public class DoneableEntandoPlugin extends EntandoPluginFluent<DoneableEntandoPl
 
     @Override
     public EntandoPlugin done() {
-        return function.apply(new EntandoPlugin(spec.build(), metadata.build(), entandoStatus));
+        return function.apply(new EntandoPlugin(metadata.build(), spec.build(), entandoStatus));
     }
 }

--- a/src/main/java/org/entando/kubernetes/model/plugin/EntandoPlugin.java
+++ b/src/main/java/org/entando/kubernetes/model/plugin/EntandoPlugin.java
@@ -40,7 +40,7 @@ public class EntandoPlugin extends CustomResource implements EntandoCustomResour
         super.setMetadata(metadata);
     }
 
-    public EntandoPlugin(EntandoPluginSpec spec, ObjectMeta metaData, EntandoCustomResourceStatus status) {
+    public EntandoPlugin(ObjectMeta metaData, EntandoPluginSpec spec, EntandoCustomResourceStatus status) {
         this(metaData, spec);
         this.entandoStatus = status;
     }

--- a/src/main/java/org/entando/kubernetes/model/plugin/EntandoPlugin.java
+++ b/src/main/java/org/entando/kubernetes/model/plugin/EntandoPlugin.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.CustomResource;
+import java.util.Optional;
 import org.entando.kubernetes.model.EntandoCustomResource;
 import org.entando.kubernetes.model.EntandoCustomResourceStatus;
 import org.entando.kubernetes.model.RequiresKeycloak;
@@ -63,12 +64,7 @@ public class EntandoPlugin extends CustomResource implements EntandoCustomResour
     }
 
     @Override
-    public String getKeycloakServerNamespace() {
-        return spec.getKeycloakServerNamespace();
-    }
-
-    @Override
-    public String getKeycloakServerName() {
-        return spec.getKeycloakServerName();
+    public Optional<String> getKeycloakSecretToUse() {
+        return spec.getKeycloakSecretToUse();
     }
 }

--- a/src/main/java/org/entando/kubernetes/model/plugin/EntandoPluginOperationFactory.java
+++ b/src/main/java/org/entando/kubernetes/model/plugin/EntandoPluginOperationFactory.java
@@ -1,0 +1,58 @@
+package org.entando.kubernetes.model.plugin;
+
+import static java.lang.Thread.sleep;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.internal.CustomResourceOperationsImpl;
+import java.util.List;
+
+public final class EntandoPluginOperationFactory {
+
+    private static final int NOT_FOUND = 404;
+    private static CustomResourceDefinition entandoPluginCrd;
+
+    private EntandoPluginOperationFactory() {
+    }
+
+    public static CustomResourceOperationsImpl<EntandoPlugin, EntandoPluginList,
+            DoneableEntandoPlugin> produceAllEntandoPlugins(
+            KubernetesClient client) throws InterruptedException {
+        synchronized (EntandoPluginOperationFactory.class) {
+            entandoPluginCrd = client.customResourceDefinitions().withName(EntandoPlugin.CRD_NAME).get();
+            if (entandoPluginCrd == null) {
+                List<HasMetadata> list = client.load(Thread.currentThread().getContextClassLoader()
+                        .getResourceAsStream("crd/EntandoPluginCRD.yaml")).get();
+                entandoPluginCrd = (CustomResourceDefinition) list.get(0);
+                // see issue https://github.com/fabric8io/kubernetes-client/issues/1486
+                entandoPluginCrd.getSpec().getValidation().getOpenAPIV3Schema().setDependencies(null);
+                client.customResourceDefinitions().create(entandoPluginCrd);
+            }
+
+        }
+        CustomResourceOperationsImpl<EntandoPlugin, EntandoPluginList,
+                DoneableEntandoPlugin>
+                oper = (CustomResourceOperationsImpl<EntandoPlugin, EntandoPluginList,
+                DoneableEntandoPlugin>) client
+                .customResources(entandoPluginCrd, EntandoPlugin.class, EntandoPluginList.class,
+                        DoneableEntandoPlugin.class);
+        while (notAvailable(oper)) {
+            sleep(100);
+        }
+        return oper;
+    }
+
+    private static boolean notAvailable(
+            CustomResourceOperationsImpl<EntandoPlugin, EntandoPluginList,
+                    DoneableEntandoPlugin> oper) {
+        try {
+            oper.inNamespace("default").list().getItems().size();
+            return false;
+        } catch (KubernetesClientException e) {
+            return e.getCode() == NOT_FOUND;
+        }
+    }
+
+}

--- a/src/main/java/org/entando/kubernetes/model/plugin/EntandoPluginSpec.java
+++ b/src/main/java/org/entando/kubernetes/model/plugin/EntandoPluginSpec.java
@@ -43,7 +43,7 @@ public class EntandoPluginSpec implements KubernetesResource {
     }
 
     /**
-     * Only for use from the builder
+     * Only for use from the builder.
      */
 
     @SuppressWarnings("PMD.ExcessiveParameterList")

--- a/src/main/java/org/entando/kubernetes/model/plugin/EntandoPluginSpecBuilder.java
+++ b/src/main/java/org/entando/kubernetes/model/plugin/EntandoPluginSpecBuilder.java
@@ -20,8 +20,8 @@ public class EntandoPluginSpecBuilder<N extends EntandoPluginSpecBuilder> {
     private int replicas = 1;
     private DbmsImageVendor dbms;
     private String ingressPath;
-    private String keycloakServerNamespace;
-    private String keycloakServerName;
+    private String keycloakSecretToUse;
+    private String clusterInfrastructureToUse;
     private String healthCheckPath;
     private PluginSecurityLevel securityLevel;
 
@@ -44,10 +44,15 @@ public class EntandoPluginSpecBuilder<N extends EntandoPluginSpecBuilder> {
         this.replicas = spec.getReplicas();
         this.dbms = spec.getDbms().orElse(null);
         this.ingressPath = spec.getIngressPath();
-        this.keycloakServerName = spec.getKeycloakServerName();
-        this.keycloakServerNamespace = spec.getKeycloakServerNamespace();
+        this.keycloakSecretToUse = spec.getKeycloakSecretToUse().orElse(null);
         this.healthCheckPath = spec.getHealthCheckPath();
         this.securityLevel = spec.getSecurityLevel().orElse(null);
+        this.clusterInfrastructureToUse = spec.getClusterInfrastructureTouse().orElse(null);
+    }
+
+    public N withClusterInfrastructureToUse(String name) {
+        this.clusterInfrastructureToUse = name;
+        return (N) this;
     }
 
     public N withDbms(DbmsImageVendor dbms) {
@@ -75,9 +80,8 @@ public class EntandoPluginSpecBuilder<N extends EntandoPluginSpecBuilder> {
         return (N) this;
     }
 
-    public N withKeycloakServer(String namespace, String name) {
-        this.keycloakServerName = name;
-        this.keycloakServerNamespace = namespace;
+    public N withKeycloakSecretToUse(String name) {
+        this.keycloakSecretToUse = name;
         return (N) this;
     }
 
@@ -119,8 +123,8 @@ public class EntandoPluginSpecBuilder<N extends EntandoPluginSpecBuilder> {
 
     public EntandoPluginSpec build() {
         return new EntandoPluginSpec(entandoAppNamespace, entandoAppName, image, dbms, replicas, ingressPath,
-                keycloakServerNamespace, keycloakServerName, healthCheckPath, securityLevel, roles, permissions, parameters,
-                connectionConfigNames);
+                keycloakSecretToUse, healthCheckPath, securityLevel, roles, permissions, parameters,
+                connectionConfigNames, clusterInfrastructureToUse);
     }
 
     public N withHealthCheckPath(String healthCheckPath) {

--- a/src/main/java/org/entando/kubernetes/model/plugin/PluginSecurityLevel.java
+++ b/src/main/java/org/entando/kubernetes/model/plugin/PluginSecurityLevel.java
@@ -2,11 +2,14 @@ package org.entando.kubernetes.model.plugin;
 
 import static java.util.Optional.ofNullable;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Locale;
 
 public enum PluginSecurityLevel {
     STRICT, LENIENT;
 
+    @JsonCreator
     public static PluginSecurityLevel forName(String name) {
         try {
             return ofNullable(name).map(PluginSecurityLevel::resolve).orElse(null);
@@ -19,6 +22,7 @@ public enum PluginSecurityLevel {
         return PluginSecurityLevel.valueOf(s.toUpperCase(Locale.getDefault()));
     }
 
+    @JsonValue
     public String toName() {
         return name().toLowerCase(Locale.getDefault());
     }

--- a/src/main/resources/crd/EntandoAppPluginLinkCRD.yaml
+++ b/src/main/resources/crd/EntandoAppPluginLinkCRD.yaml
@@ -1,0 +1,26 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: entandoapppluginlinks.entando.org
+spec:
+  group: entando.org
+  version: v1alpha1
+  names:
+    kind: EntandoAppPluginLink
+    plural: entandoapppluginlinks
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            entandoAppName:
+              type: string
+            entandoAppNamespace:
+              type: string
+            entandoPluginName:
+              type: string
+            entandoPluginNamespace:
+              type: string
+        entandoStatus: {}

--- a/src/main/resources/crd/EntandoClusterInfrastructureCRD.yaml
+++ b/src/main/resources/crd/EntandoClusterInfrastructureCRD.yaml
@@ -2,13 +2,13 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: entandoapps.entando.org
+  name: entandoclusterinfrastructures.entando.org
 spec:
   group: entando.org
   version: v1alpha1
   names:
-    kind: EntandoApp
-    plural: entandoapps
+    kind: EntandoClusterInfrastructure
+    plural: entandoclusterinfrastructures
   scope: Namespaced
   validation:
     openAPIV3Schema:
@@ -16,31 +16,23 @@ spec:
         spec:
           type: object
           properties:
-            standardServerImage:
-              type: string
-              pattern: '^(wildfly|eap|tomcat|jetty)$'
-            customServerImage:
-              type: string
             dbms:
               type: string
               pattern: '^(mysql|oracle|postgresql|none)$'
-            tlsSecretName:
-              type: string
-              pattern: '^([a-z])+([a-z0-9-\.])*[a-z0-9]$'
             ingressHostName:
               type: string
               pattern: '^([A-Za-z0-9-]{1,63}\.)+[[A-Za-z0-9-]{1,63}$'
             entandoImageVersion:
               type: string
+            tlsSecretName:
+              type: string
+              pattern: '^([a-z])+([a-z0-9-\.])*[a-z0-9]$'
+            keycloakSecretToUse:
+              type: string
+              pattern: '^([a-z])+([a-z0-9-\.])*[a-z0-9]$'
             replicas:
               type: integer
               minimum: 1
               maximum: 10
-            keycloakSecretToUse:
-              type: string
-              pattern: '^([a-z])+([a-z0-9-\.])*[a-z0-9]$'
-            clusterInfrastructureToUse:
-              type: string
-              pattern: '^([a-z])+([a-z0-9-\.])*[a-z0-9]$'
         entandoStatus: {}
 

--- a/src/main/resources/crd/EntandoKeycloakServerCRD.yaml
+++ b/src/main/resources/crd/EntandoKeycloakServerCRD.yaml
@@ -21,8 +21,8 @@ spec:
             dbms:
               type: string
               pattern: '^(mysql|oracle|postgresql|none)$'
-            tlsEnabled:
-              type: boolean
+            tlsSecretName:
+              type: string
             ingressHostName:
               type: string
               pattern: '^([A-Za-z0-9-]{1,63}\.)+[[A-Za-z0-9-]{1,63}$'

--- a/src/main/resources/crd/EntandoPluginCRD.yaml
+++ b/src/main/resources/crd/EntandoPluginCRD.yaml
@@ -26,10 +26,10 @@ spec:
               type: string
             healthCheckPath:
               type: string
-            keycloakServerName:
+            keycloakSecretToUse:
               type: string
               pattern: '^([a-z])+([a-z0-9-\.])*[a-z0-9]$'
-            keycloakServerNamespace:
+            clusterInfrastructureToUse:
               type: string
               pattern: '^([a-z])+([a-z0-9-\.])*[a-z0-9]$'
             dbms:

--- a/src/test/java/org/entando/kubernetes/model/AbstractEntandoAppPluginLinkTest.java
+++ b/src/test/java/org/entando/kubernetes/model/AbstractEntandoAppPluginLinkTest.java
@@ -20,7 +20,7 @@ public abstract class AbstractEntandoAppPluginLinkTest implements CustomResource
     private static final String MY_APP = "my-app";
 
     @BeforeEach
-    public void deleteentandoAppPluginLinks() throws InterruptedException {
+    public void deleteEntandoAppPluginLinks() throws InterruptedException {
         prepareNamespace(entandoAppPluginLinks(), MY_APP_NAMESPACE);
     }
 

--- a/src/test/java/org/entando/kubernetes/model/AbstractEntandoAppPluginLinkTest.java
+++ b/src/test/java/org/entando/kubernetes/model/AbstractEntandoAppPluginLinkTest.java
@@ -1,0 +1,96 @@
+package org.entando.kubernetes.model;
+
+import static org.entando.kubernetes.model.link.EntandoAppPluginLinkOperationFactory.produceAllEntandoAppPluginLinks;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import io.fabric8.kubernetes.client.dsl.internal.CustomResourceOperationsImpl;
+import org.entando.kubernetes.model.link.DoneableEntandoAppPluginLink;
+import org.entando.kubernetes.model.link.EntandoAppPluginLink;
+import org.entando.kubernetes.model.link.EntandoAppPluginLinkBuilder;
+import org.entando.kubernetes.model.link.EntandoAppPluginLinkList;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public abstract class AbstractEntandoAppPluginLinkTest implements CustomResourceTestUtil {
+
+    public static final String MY_APP_NAMESPACE = "my-app-namespace";
+    public static final String MY_PLUGIN_NAMEPSACE = "my-plugin-namepsace";
+    protected static final String MY_PLUGIN = "my-plugin";
+    private static final String MY_APP = "my-app";
+
+    @BeforeEach
+    public void deleteentandoAppPluginLinks() throws InterruptedException {
+        prepareNamespace(entandoAppPluginLinks(), MY_APP_NAMESPACE);
+    }
+
+    @Test
+    public void testCreateEntandoAppPluginLink() throws InterruptedException {
+        //Given
+        EntandoAppPluginLink externalDatabase = new EntandoAppPluginLinkBuilder()
+                .withNewMetadata().withName(MY_PLUGIN)
+                .withNamespace(MY_APP_NAMESPACE)
+                .endMetadata()
+                .withNewSpec()
+                .withEntandoApp(MY_APP_NAMESPACE, MY_APP)
+                .withEntandoPlugin(MY_PLUGIN_NAMEPSACE, MY_PLUGIN)
+                .endSpec()
+                .build();
+        getClient().namespaces().createOrReplaceWithNew().withNewMetadata().withName(MY_APP_NAMESPACE).endMetadata().done();
+        entandoAppPluginLinks().inNamespace(MY_APP_NAMESPACE).create(externalDatabase);
+        //When
+        EntandoAppPluginLinkList list = entandoAppPluginLinks().inNamespace(MY_APP_NAMESPACE).list();
+        EntandoAppPluginLink actual = list.getItems().get(0);
+        //Then
+        assertThat(actual.getSpec().getEntandoAppName(), is(MY_APP));
+        assertThat(actual.getSpec().getEntandoAppNamespace(), is(MY_APP_NAMESPACE));
+        assertThat(actual.getSpec().getEntandoPluginName(), is(MY_PLUGIN));
+        assertThat(actual.getSpec().getEntandoPluginNamespace(), is(MY_PLUGIN_NAMEPSACE));
+        assertThat(actual.getMetadata().getName(), is(MY_PLUGIN));
+    }
+
+    @Test
+    public void testEditEntandoAppPluginLink() throws InterruptedException {
+        //Given
+        EntandoAppPluginLink entandoAppPluginLink = new EntandoAppPluginLinkBuilder()
+                .withNewMetadata()
+                .withName(MY_PLUGIN)
+                .withNamespace(MY_APP_NAMESPACE)
+                .endMetadata()
+                .withNewSpec()
+                .withEntandoApp("some-namespace", "some-app")
+                .withEntandoPlugin("antoher-namespace", "some-plugin")
+                .endSpec()
+                .build();
+        getClient().namespaces().createOrReplaceWithNew().withNewMetadata().withName(MY_APP_NAMESPACE).endMetadata().done();
+        //When
+        //We are not using the mock server here because of a known bug
+        EntandoAppPluginLink actual = editEntandoAppPluginLink(entandoAppPluginLink)
+                .editMetadata().addToLabels("my-label", "my-value")
+                .endMetadata()
+                .editSpec()
+                .withEntandoApp(MY_APP_NAMESPACE, MY_APP)
+                .withEntandoPlugin(MY_PLUGIN_NAMEPSACE, MY_PLUGIN)
+                .endSpec()
+                .withStatus(new WebServerStatus("some-qualifier"))
+                .withStatus(new DbServerStatus("another-qualifier"))
+                .withPhase(EntandoDeploymentPhase.STARTED)
+                .done();
+        //Then
+        assertThat(actual.getSpec().getEntandoAppName(), is(MY_APP));
+        assertThat(actual.getSpec().getEntandoAppNamespace(), is(MY_APP_NAMESPACE));
+        assertThat(actual.getSpec().getEntandoPluginName(), is(MY_PLUGIN));
+        assertThat(actual.getSpec().getEntandoPluginNamespace(), is(MY_PLUGIN_NAMEPSACE));
+        assertThat(actual.getMetadata().getName(), is(MY_PLUGIN));
+    }
+
+    protected abstract DoneableEntandoAppPluginLink editEntandoAppPluginLink(EntandoAppPluginLink entandoAppPluginLink)
+            throws InterruptedException;
+
+    protected CustomResourceOperationsImpl<EntandoAppPluginLink, EntandoAppPluginLinkList,
+            DoneableEntandoAppPluginLink> entandoAppPluginLinks()
+            throws InterruptedException {
+        return produceAllEntandoAppPluginLinks(getClient());
+    }
+
+}

--- a/src/test/java/org/entando/kubernetes/model/AbstractEntandoClusterInfrastructureTest.java
+++ b/src/test/java/org/entando/kubernetes/model/AbstractEntandoClusterInfrastructureTest.java
@@ -1,79 +1,81 @@
 package org.entando.kubernetes.model;
 
-import static org.entando.kubernetes.model.keycloakserver.KeycloakServerOperationFactory.produceAllKeycloakServers;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import io.fabric8.kubernetes.client.dsl.internal.CustomResourceOperationsImpl;
-import org.entando.kubernetes.model.keycloakserver.DoneableKeycloakServer;
-import org.entando.kubernetes.model.keycloakserver.KeycloakServer;
-import org.entando.kubernetes.model.keycloakserver.KeycloakServerBuilder;
-import org.entando.kubernetes.model.keycloakserver.KeycloakServerList;
+import org.entando.kubernetes.model.infrastructure.DoneableEntandoClusterInfrastructure;
+import org.entando.kubernetes.model.infrastructure.EntandoClusterInfrastructure;
+import org.entando.kubernetes.model.infrastructure.EntandoClusterInfrastructureBuilder;
+import org.entando.kubernetes.model.infrastructure.EntandoClusterInfrastructureList;
+import org.entando.kubernetes.model.infrastructure.EntandoClusterInfrastructureOperationFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public abstract class AbstractKeycloakServerTest implements CustomResourceTestUtil {
+public abstract class AbstractEntandoClusterInfrastructureTest implements CustomResourceTestUtil {
 
     protected static final String MY_NAMESPACE = "my-namespace";
-    protected static final String MY_KEYCLOAK = "my-keycloak";
+    protected static final String MY_ENTANDO_CLUSTER_INFRASTRUCTURE = "my-entando-cluster-infrastructure";
 
     private static final String SNAPSHOT = "6.1.0-SNAPSHOT";
-    private static final String ENTANDO_SOMEKEYCLOAK = "entando/somekeycloak";
     private static final String MYHOST_COM = "myhost.com";
     private static final String MY_TLS_SECRET = "my-tls-secret";
+    private static final String MY_KEYCLOAK_SECRET = "my-keycloak-secret";
 
     @BeforeEach
-    public void deleteKeycloakServer() throws InterruptedException {
-        prepareNamespace(keycloakServers(), MY_NAMESPACE);
+    public void deleteEntandoClusterInfrastructure() throws InterruptedException {
+        prepareNamespace(entandoInfrastructure(), MY_NAMESPACE);
     }
 
     @Test
-    public void testCreateKeycloakServer() throws InterruptedException {
+    public void testCreateEntandoClusterInfrastructure() throws InterruptedException {
         //Given
-        KeycloakServer keycloakServer = new KeycloakServerBuilder()
-                .withNewMetadata().withName(MY_KEYCLOAK)
+        EntandoClusterInfrastructure externalDatabase = new EntandoClusterInfrastructureBuilder()
+                .withNewMetadata().withName(MY_ENTANDO_CLUSTER_INFRASTRUCTURE)
                 .withNamespace(MY_NAMESPACE)
                 .endMetadata()
                 .withNewSpec()
                 .withDbms(DbmsImageVendor.MYSQL)
                 .withEntandoImageVersion(SNAPSHOT)
-                .withImageName(ENTANDO_SOMEKEYCLOAK)
                 .withReplicas(5)
-                .withDefault(true)
                 .withIngressHostName(MYHOST_COM)
                 .withTlsSecretName(MY_TLS_SECRET)
+                .withKeycloakSecretToUse(MY_KEYCLOAK_SECRET)
+                .withDefault(true)
                 .endSpec()
                 .build();
         getClient().namespaces().createOrReplaceWithNew().withNewMetadata().withName(MY_NAMESPACE).endMetadata().done();
-        keycloakServers().inNamespace(MY_NAMESPACE).create(keycloakServer);
+        entandoInfrastructure().inNamespace(MY_NAMESPACE).create(externalDatabase);
         //When
-        KeycloakServerList list = keycloakServers().inNamespace(MY_NAMESPACE).list();
-        KeycloakServer actual = list.getItems().get(0);
+        EntandoClusterInfrastructureList list = entandoInfrastructure().inNamespace(MY_NAMESPACE).list();
+        EntandoClusterInfrastructure actual = list.getItems().get(0);
         //Then
         assertThat(actual.getSpec().getDbms().get(), is(DbmsImageVendor.MYSQL));
         assertThat(actual.getSpec().getEntandoImageVersion().get(), is(SNAPSHOT));
-        assertThat(actual.getSpec().getImageName().get(), is(ENTANDO_SOMEKEYCLOAK));
+        assertThat(actual.getSpec().getKeycloakSecretToUse().get(), is(MY_KEYCLOAK_SECRET));
+        assertThat(actual.getKeycloakSecretToUse().get(), is(MY_KEYCLOAK_SECRET));
         assertThat(actual.getSpec().getIngressHostName().get(), is(MYHOST_COM));
         assertThat(actual.getSpec().getReplicas(), is(5));
         assertThat(actual.getSpec().getTlsSecretName().get(), is(MY_TLS_SECRET));
         assertThat(actual.getSpec().isDefault(), is(true));
-        assertThat(actual.getMetadata().getName(), is(MY_KEYCLOAK));
+        assertThat(actual.getTlsSecretName().get(), is(MY_TLS_SECRET));
+        assertThat(actual.getMetadata().getName(), is(MY_ENTANDO_CLUSTER_INFRASTRUCTURE));
     }
 
     @Test
-    public void testEditKeycloakServer() throws InterruptedException {
+    public void testEditEntandoClusterInfrastructure() throws InterruptedException {
         //Given
-        KeycloakServer keycloakServer = new KeycloakServerBuilder()
+        EntandoClusterInfrastructure keycloakServer = new EntandoClusterInfrastructureBuilder()
                 .withNewMetadata()
-                .withName(MY_KEYCLOAK)
+                .withName(MY_ENTANDO_CLUSTER_INFRASTRUCTURE)
                 .withNamespace(MY_NAMESPACE)
                 .endMetadata()
                 .withNewSpec()
                 .withDbms(DbmsImageVendor.POSTGRESQL)
                 .withEntandoImageVersion("6.2.0-SNAPSHOT")
                 .withIngressHostName(MYHOST_COM)
-                .withImageName("entando/anotherkeycloak")
                 .withReplicas(3)
+                .withKeycloakSecretToUse("some-othersecret")
                 .withTlsSecretName("some-othersecret")
                 .withDefault(false)
                 .endSpec()
@@ -82,17 +84,17 @@ public abstract class AbstractKeycloakServerTest implements CustomResourceTestUt
 
         //When
         //We are not using the mock server here because of a known bug
-        KeycloakServer actual = editKeycloakServer(keycloakServer)
+        EntandoClusterInfrastructure actual = editEntandoClusterInfrastructure(keycloakServer)
                 .editMetadata().addToLabels("my-label", "my-value")
                 .endMetadata()
                 .editSpec()
                 .withDbms(DbmsImageVendor.MYSQL)
                 .withEntandoImageVersion(SNAPSHOT)
-                .withImageName(ENTANDO_SOMEKEYCLOAK)
                 .withIngressHostName(MYHOST_COM)
                 .withReplicas(5)
-                .withDefault(true)
+                .withKeycloakSecretToUse(MY_KEYCLOAK_SECRET)
                 .withTlsSecretName(MY_TLS_SECRET)
+                .withDefault(true)
                 .endSpec()
                 .withStatus(new WebServerStatus("some-qualifier"))
                 .withStatus(new WebServerStatus("some-other-qualifier"))
@@ -103,21 +105,22 @@ public abstract class AbstractKeycloakServerTest implements CustomResourceTestUt
         //Then
         assertThat(actual.getSpec().getDbms().get(), is(DbmsImageVendor.MYSQL));
         assertThat(actual.getSpec().getEntandoImageVersion().get(), is(SNAPSHOT));
-        assertThat(actual.getSpec().getImageName().get(), is(ENTANDO_SOMEKEYCLOAK));
+        assertThat(actual.getSpec().getKeycloakSecretToUse().get(), is(MY_KEYCLOAK_SECRET));
         assertThat(actual.getSpec().getIngressHostName().get(), is(MYHOST_COM));
         assertThat(actual.getSpec().getReplicas(), is(5));
         assertThat(actual.getSpec().getTlsSecretName().get(), is(MY_TLS_SECRET));
         assertThat(actual.getSpec().isDefault(), is(true));
-        assertThat(actual.getMetadata().getName(), is(MY_KEYCLOAK));
+        assertThat(actual.getMetadata().getName(), is(MY_ENTANDO_CLUSTER_INFRASTRUCTURE));
         assertThat("the status reflects", actual.getStatus().forServerQualifiedBy("some-qualifier").isPresent());
         assertThat("the status reflects", actual.getStatus().forServerQualifiedBy("some-other-qualifier").isPresent());
         assertThat("the status reflects", actual.getStatus().forDbQualifiedBy("another-qualifier").isPresent());
     }
 
-    protected abstract DoneableKeycloakServer editKeycloakServer(KeycloakServer keycloakServer) throws InterruptedException;
+    protected abstract DoneableEntandoClusterInfrastructure editEntandoClusterInfrastructure(EntandoClusterInfrastructure
+            keycloakServer) throws InterruptedException;
 
-    protected CustomResourceOperationsImpl<KeycloakServer, KeycloakServerList, DoneableKeycloakServer> keycloakServers()
-            throws InterruptedException {
-        return produceAllKeycloakServers(getClient());
+    protected CustomResourceOperationsImpl<EntandoClusterInfrastructure, EntandoClusterInfrastructureList,
+            DoneableEntandoClusterInfrastructure> entandoInfrastructure() throws InterruptedException {
+        return EntandoClusterInfrastructureOperationFactory.produceAllEntandoClusterInfrastructures(getClient());
     }
 }

--- a/src/test/java/org/entando/kubernetes/model/AbstractEntandoPluginTest.java
+++ b/src/test/java/org/entando/kubernetes/model/AbstractEntandoPluginTest.java
@@ -1,17 +1,13 @@
 package org.entando.kubernetes.model;
 
+import static org.entando.kubernetes.model.plugin.EntandoPluginOperationFactory.produceAllEntandoPlugins;
 import static org.entando.kubernetes.model.plugin.PluginSecurityLevel.STRICT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.internal.CustomResourceOperationsImpl;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
-import org.entando.kubernetes.model.inprocesstest.EntandoPluginMockedTest;
 import org.entando.kubernetes.model.plugin.DoneableEntandoPlugin;
 import org.entando.kubernetes.model.plugin.EntandoPlugin;
 import org.entando.kubernetes.model.plugin.EntandoPluginBuilder;
@@ -21,8 +17,9 @@ import org.entando.kubernetes.model.plugin.Permission;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public abstract class AbstractEntandoPluginTest {
+public abstract class AbstractEntandoPluginTest implements CustomResourceTestUtil {
 
+    public static final String MY_CLUSTER_INFRASTRUCTURE = "my-cluster-infrastructure";
     protected static final String MY_NAMESPACE = "my-namespace";
     protected static final String MY_PLUGIN = "my-plugin";
     private static final String IMAGE = "entando/someplugin:1.0.2";
@@ -35,39 +32,16 @@ public abstract class AbstractEntandoPluginTest {
     private static final String ADMINISTRATOR = "Administrator";
     private static final String PARAMETER_NAME = "env";
     private static final String PARAMETER_VALUE = "B";
-    private static final String MYKEYCLOAKNAMESPACE = "mykeycloaknamespace";
-    private static final String MY_KEYCLOAK = "my-keycloak";
+    private static final String MY_KEYCLOAK_SECRET = "my-keycloak-secret";
     private static final String MY_APP = "my-app";
-    private static CustomResourceDefinition entandoPluginCrd;
-
-    private static CustomResourceOperationsImpl<EntandoPlugin, EntandoPluginList,
-            DoneableEntandoPlugin> produceAllEntandoPlugins(
-            KubernetesClient client) {
-        synchronized (EntandoPluginMockedTest.class) {
-            entandoPluginCrd = client.customResourceDefinitions().withName(EntandoPlugin.CRD_NAME).get();
-            if (entandoPluginCrd == null) {
-                List<HasMetadata> list = client.load(Thread.currentThread().getContextClassLoader()
-                        .getResourceAsStream("crd/EntandoPluginCRD.yaml")).get();
-                entandoPluginCrd = (CustomResourceDefinition) list.get(0);
-                // see issue https://github.com/fabric8io/kubernetes-client/issues/1486
-                entandoPluginCrd.getSpec().getValidation().getOpenAPIV3Schema().setDependencies(null);
-                client.customResourceDefinitions().create(entandoPluginCrd);
-            }
-        }
-        return (CustomResourceOperationsImpl<EntandoPlugin, EntandoPluginList, DoneableEntandoPlugin>) client
-                .customResources(entandoPluginCrd, EntandoPlugin.class, EntandoPluginList.class, DoneableEntandoPlugin.class);
-    }
 
     @BeforeEach
-    public void deleteEntandPlugin() throws InterruptedException {
-        entandoPlugins().inNamespace(MY_NAMESPACE).withName(MY_PLUGIN).delete();
-        while (entandoPlugins().inNamespace(MY_NAMESPACE).list().getItems().size() > 0) {
-            Thread.sleep(100);
-        }
+    public void deleteEntandoPlugins() throws InterruptedException {
+        prepareNamespace(entandoPlugins(), MY_NAMESPACE);
     }
 
     @Test
-    public void testCreateEntandoPlugin() {
+    public void testCreateEntandoPlugin() throws InterruptedException {
         //Given
         EntandoPlugin externalDatabase = new EntandoPluginBuilder()
                 .withNewMetadata().withName(MY_PLUGIN)
@@ -85,7 +59,8 @@ public abstract class AbstractEntandoPluginTest {
                 .addNewParameter(PARAMETER_NAME, PARAMETER_VALUE)
                 .withSecurityLevel(STRICT)
                 .withEntandoApp(MY_NAMESPACE, MY_APP)
-                .withKeycloakServer(MYKEYCLOAKNAMESPACE, MY_KEYCLOAK)
+                .withKeycloakSecretToUse(MY_KEYCLOAK_SECRET)
+                .withClusterInfrastructureToUse(MY_CLUSTER_INFRASTRUCTURE)
                 .endSpec()
                 .build();
         getClient().namespaces().createOrReplaceWithNew().withNewMetadata().withName(MY_NAMESPACE).endMetadata().done();
@@ -96,10 +71,8 @@ public abstract class AbstractEntandoPluginTest {
         //Then
         assertThat(actual.getSpec().getDbms().get(), is(DbmsImageVendor.MYSQL));
         assertThat(actual.getSpec().getImage(), is(IMAGE));
-        assertThat(actual.getSpec().getKeycloakServerName(), is(MY_KEYCLOAK));
-        assertThat(actual.getSpec().getKeycloakServerNamespace(), is(MYKEYCLOAKNAMESPACE));
-        assertThat(actual.getKeycloakServerName(), is(MY_KEYCLOAK));
-        assertThat(actual.getKeycloakServerNamespace(), is(MYKEYCLOAKNAMESPACE));
+        assertThat(actual.getSpec().getKeycloakSecretToUse().get(), is(MY_KEYCLOAK_SECRET));
+        assertThat(actual.getKeycloakSecretToUse().get(), is(MY_KEYCLOAK_SECRET));
         assertThat(actual.getSpec().getEntandoAppName(), is(MY_APP));
         assertThat(actual.getSpec().getEntandoAppNamespace(), is(MY_NAMESPACE));
         assertThat(actual.getSpec().getConnectionConfigNames(), is(Arrays.asList(SOME_CONNECTION)));
@@ -112,11 +85,12 @@ public abstract class AbstractEntandoPluginTest {
         assertThat(actual.getSpec().getIngressPath(), is(INGRESS_PATH));
         assertThat(actual.getSpec().getHealthCheckPath(), is(ACTUATOR_HEALTH));
         assertThat(actual.getSpec().getReplicas(), is(5));
+        assertThat(actual.getSpec().getClusterInfrastructureTouse().get(), is(MY_CLUSTER_INFRASTRUCTURE));
         assertThat(actual.getMetadata().getName(), is(MY_PLUGIN));
     }
 
     @Test
-    public void testEditEntandoPlugin() {
+    public void testEditEntandoPlugin() throws InterruptedException {
         //Given
         EntandoPlugin entandoPlugin = new EntandoPluginBuilder()
                 .withNewMetadata()
@@ -135,7 +109,8 @@ public abstract class AbstractEntandoPluginTest {
                 .addNewParameter(PARAMETER_NAME, "A")
                 .withSecurityLevel(STRICT)
                 .withEntandoApp("somenamespace", "another-app")
-                .withKeycloakServer("somekeycloaknamespace", "another-keycloak")
+                .withKeycloakSecretToUse("another-keycloak-secret")
+                .withClusterInfrastructureToUse("another-cluster-infrastructure")
                 .endSpec()
                 .build();
         getClient().namespaces().createOrReplaceWithNew().withNewMetadata().withName(MY_NAMESPACE).endMetadata().done();
@@ -155,7 +130,8 @@ public abstract class AbstractEntandoPluginTest {
                 .withParameters(Collections.singletonMap(PARAMETER_NAME, PARAMETER_VALUE))
                 .withSecurityLevel(STRICT)
                 .withEntandoApp(MY_NAMESPACE, MY_APP)
-                .withKeycloakServer(MYKEYCLOAKNAMESPACE, MY_KEYCLOAK)
+                .withKeycloakSecretToUse(MY_KEYCLOAK_SECRET)
+                .withClusterInfrastructureToUse(MY_CLUSTER_INFRASTRUCTURE)
                 .endSpec()
                 .withStatus(new WebServerStatus("some-qualifier"))
                 .withStatus(new DbServerStatus("another-qualifier"))
@@ -164,10 +140,8 @@ public abstract class AbstractEntandoPluginTest {
         //Then
         assertThat(actual.getSpec().getDbms().get(), is(DbmsImageVendor.MYSQL));
         assertThat(actual.getSpec().getImage(), is(IMAGE));
-        assertThat(actual.getSpec().getKeycloakServerName(), is(MY_KEYCLOAK));
-        assertThat(actual.getSpec().getKeycloakServerNamespace(), is(MYKEYCLOAKNAMESPACE));
-        assertThat(actual.getKeycloakServerName(), is(MY_KEYCLOAK));
-        assertThat(actual.getKeycloakServerNamespace(), is(MYKEYCLOAKNAMESPACE));
+        assertThat(actual.getSpec().getKeycloakSecretToUse().get(), is(MY_KEYCLOAK_SECRET));
+        assertThat(actual.getKeycloakSecretToUse().get(), is(MY_KEYCLOAK_SECRET));
         assertThat(actual.getSpec().getEntandoAppName(), is(MY_APP));
         assertThat(actual.getSpec().getEntandoAppNamespace(), is(MY_NAMESPACE));
         assertThat(actual.getSpec().getConnectionConfigNames(), is(Arrays.asList(SOME_CONNECTION)));
@@ -178,15 +152,15 @@ public abstract class AbstractEntandoPluginTest {
         assertThat(actual.getSpec().getSecurityLevel().get(), is(STRICT));
         assertThat(actual.getSpec().getParameters().get(PARAMETER_NAME), is(PARAMETER_VALUE));
         assertThat(actual.getSpec().getReplicas(), is(5));
+        assertThat(actual.getSpec().getClusterInfrastructureTouse().get(), is(MY_CLUSTER_INFRASTRUCTURE));
         assertThat(actual.getMetadata().getName(), is(MY_PLUGIN));
     }
 
-    protected abstract DoneableEntandoPlugin editEntandoPlugin(EntandoPlugin entandoPlugin);
+    protected abstract DoneableEntandoPlugin editEntandoPlugin(EntandoPlugin entandoPlugin) throws InterruptedException;
 
-    protected CustomResourceOperationsImpl<EntandoPlugin, EntandoPluginList, DoneableEntandoPlugin> entandoPlugins() {
-        return produceAllEntandoPlugins(
-                getClient());
+    protected CustomResourceOperationsImpl<EntandoPlugin, EntandoPluginList, DoneableEntandoPlugin> entandoPlugins()
+            throws InterruptedException {
+        return produceAllEntandoPlugins(getClient());
     }
 
-    protected abstract KubernetesClient getClient();
 }

--- a/src/test/java/org/entando/kubernetes/model/CustomResourceTestUtil.java
+++ b/src/test/java/org/entando/kubernetes/model/CustomResourceTestUtil.java
@@ -1,0 +1,26 @@
+package org.entando.kubernetes.model;
+
+import io.fabric8.kubernetes.client.CustomResourceList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.internal.CustomResourceOperationsImpl;
+
+public interface CustomResourceTestUtil {
+
+    default void prepareNamespace(CustomResourceOperationsImpl oper, String namespace) throws InterruptedException {
+        if (getClient().namespaces().withName(namespace).get() == null) {
+            getClient().namespaces().createNew().withNewMetadata().withName(namespace).endMetadata().done();
+        } else {
+            while (((CustomResourceList) oper.inNamespace(namespace).list()).getItems().size() > 0) {
+                try {
+                    oper.inNamespace(namespace)
+                            .delete(((CustomResourceList) oper.inNamespace(namespace).list()).getItems().get(0));
+                    Thread.sleep(100);
+                } catch (IndexOutOfBoundsException e) {
+                    return;
+                }
+            }
+        }
+    }
+
+    KubernetesClient getClient();
+}

--- a/src/test/java/org/entando/kubernetes/model/inprocesstest/EntandoAppMockedTest.java
+++ b/src/test/java/org/entando/kubernetes/model/inprocesstest/EntandoAppMockedTest.java
@@ -24,7 +24,7 @@ public class EntandoAppMockedTest extends AbstractEntandoAppTest {
     }
 
     @Override
-    protected KubernetesClient getClient() {
+    public KubernetesClient getClient() {
         return server.getClient();
     }
 

--- a/src/test/java/org/entando/kubernetes/model/inprocesstest/EntandoAppPluginLinkMockedTest.java
+++ b/src/test/java/org/entando/kubernetes/model/inprocesstest/EntandoAppPluginLinkMockedTest.java
@@ -1,0 +1,31 @@
+package org.entando.kubernetes.model.inprocesstest;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import org.entando.kubernetes.model.AbstractEntandoAppPluginLinkTest;
+import org.entando.kubernetes.model.link.DoneableEntandoAppPluginLink;
+import org.entando.kubernetes.model.link.EntandoAppPluginLink;
+import org.junit.Rule;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
+
+@EnableRuleMigrationSupport
+@Tag("in-process")
+@SuppressWarnings("PMD.TestClassWithoutTestCases")
+//Because PMD doesn't know they are inherited
+public class EntandoAppPluginLinkMockedTest extends AbstractEntandoAppPluginLinkTest {
+
+    @Rule
+    public KubernetesServer server = new KubernetesServer(false, true);
+
+    @Override
+    protected DoneableEntandoAppPluginLink editEntandoAppPluginLink(EntandoAppPluginLink entandoPlugin) {
+        return new DoneableEntandoAppPluginLink(entandoPlugin, builtEntandoAppPluginLink -> builtEntandoAppPluginLink);
+    }
+
+    @Override
+    public KubernetesClient getClient() {
+        return server.getClient();
+    }
+
+}

--- a/src/test/java/org/entando/kubernetes/model/inprocesstest/EntandoClusterInfrastructureMockedTest.java
+++ b/src/test/java/org/entando/kubernetes/model/inprocesstest/EntandoClusterInfrastructureMockedTest.java
@@ -2,9 +2,9 @@ package org.entando.kubernetes.model.inprocesstest;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
-import org.entando.kubernetes.model.AbstractKeycloakServerTest;
-import org.entando.kubernetes.model.keycloakserver.DoneableKeycloakServer;
-import org.entando.kubernetes.model.keycloakserver.KeycloakServer;
+import org.entando.kubernetes.model.AbstractEntandoClusterInfrastructureTest;
+import org.entando.kubernetes.model.infrastructure.DoneableEntandoClusterInfrastructure;
+import org.entando.kubernetes.model.infrastructure.EntandoClusterInfrastructure;
 import org.junit.Rule;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
@@ -13,7 +13,7 @@ import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
 @Tag("in-process")
 @SuppressWarnings("PMD.TestClassWithoutTestCases")
 //Because PMD doesn't know they are inherited
-public class KeycloakServerMockedTest extends AbstractKeycloakServerTest {
+public class EntandoClusterInfrastructureMockedTest extends AbstractEntandoClusterInfrastructureTest {
 
     @Rule
     public KubernetesServer server = new KubernetesServer(false, true);
@@ -24,8 +24,8 @@ public class KeycloakServerMockedTest extends AbstractKeycloakServerTest {
     }
 
     @Override
-    protected DoneableKeycloakServer editKeycloakServer(KeycloakServer keycloakServer) {
-        return new DoneableKeycloakServer(keycloakServer, builtKeycloakServer -> builtKeycloakServer);
+    protected DoneableEntandoClusterInfrastructure editEntandoClusterInfrastructure(EntandoClusterInfrastructure keycloakServer) {
+        return new DoneableEntandoClusterInfrastructure(keycloakServer, entandoClusterInfrastructure -> entandoClusterInfrastructure);
     }
 
 }

--- a/src/test/java/org/entando/kubernetes/model/inprocesstest/EntandoPluginMockedTest.java
+++ b/src/test/java/org/entando/kubernetes/model/inprocesstest/EntandoPluginMockedTest.java
@@ -24,7 +24,7 @@ public class EntandoPluginMockedTest extends AbstractEntandoPluginTest {
     }
 
     @Override
-    protected KubernetesClient getClient() {
+    public KubernetesClient getClient() {
         return server.getClient();
     }
 

--- a/src/test/java/org/entando/kubernetes/model/inprocesstest/ExternalDatabaseMockedTest.java
+++ b/src/test/java/org/entando/kubernetes/model/inprocesstest/ExternalDatabaseMockedTest.java
@@ -19,7 +19,7 @@ public class ExternalDatabaseMockedTest extends AbstractExternalDatabaseTest {
     public KubernetesServer server = new KubernetesServer(false, true);
 
     @Override
-    protected NamespacedKubernetesClient getClient() {
+    public NamespacedKubernetesClient getClient() {
         return this.server.getClient();
     }
 

--- a/src/test/java/org/entando/kubernetes/model/interprocesstest/EntandoAppIntegratedTest.java
+++ b/src/test/java/org/entando/kubernetes/model/interprocesstest/EntandoAppIntegratedTest.java
@@ -15,13 +15,13 @@ public class EntandoAppIntegratedTest extends AbstractEntandoAppTest {
     private final KubernetesClient client = new AutoAdaptableKubernetesClient();
 
     @Override
-    protected DoneableEntandoApp editEntandoApp(EntandoApp entandoApp) {
+    protected DoneableEntandoApp editEntandoApp(EntandoApp entandoApp) throws InterruptedException {
         entandoApps().inNamespace(MY_NAMESPACE).create(entandoApp);
         return entandoApps().inNamespace(MY_NAMESPACE).withName(MY_APP).edit();
     }
 
     @Override
-    protected KubernetesClient getClient() {
+    public KubernetesClient getClient() {
         return client;
     }
 

--- a/src/test/java/org/entando/kubernetes/model/interprocesstest/EntandoAppPluginLinkIntegratedTest.java
+++ b/src/test/java/org/entando/kubernetes/model/interprocesstest/EntandoAppPluginLinkIntegratedTest.java
@@ -1,0 +1,28 @@
+package org.entando.kubernetes.model.interprocesstest;
+
+import io.fabric8.kubernetes.client.AutoAdaptableKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.entando.kubernetes.model.AbstractEntandoAppPluginLinkTest;
+import org.entando.kubernetes.model.link.DoneableEntandoAppPluginLink;
+import org.entando.kubernetes.model.link.EntandoAppPluginLink;
+import org.junit.jupiter.api.Tag;
+
+@Tag("inter-process")
+@SuppressWarnings("PMD.TestClassWithoutTestCases")
+//Because PMD doesn't know they are inherited
+public class EntandoAppPluginLinkIntegratedTest extends AbstractEntandoAppPluginLinkTest {
+
+    private final KubernetesClient client = new AutoAdaptableKubernetesClient();
+
+    @Override
+    protected DoneableEntandoAppPluginLink editEntandoAppPluginLink(EntandoAppPluginLink entandoPlugin) throws InterruptedException {
+        entandoAppPluginLinks().inNamespace(MY_APP_NAMESPACE).create(entandoPlugin);
+        return entandoAppPluginLinks().inNamespace(MY_APP_NAMESPACE).withName(MY_PLUGIN).edit();
+    }
+
+    @Override
+    public KubernetesClient getClient() {
+        return client;
+    }
+
+}

--- a/src/test/java/org/entando/kubernetes/model/interprocesstest/EntandoClusterInfrastructureIntegratedTest.java
+++ b/src/test/java/org/entando/kubernetes/model/interprocesstest/EntandoClusterInfrastructureIntegratedTest.java
@@ -1,0 +1,48 @@
+package org.entando.kubernetes.model.interprocesstest;
+
+import io.fabric8.kubernetes.api.model.LoadBalancerStatus;
+import io.fabric8.kubernetes.api.model.PodStatus;
+import io.fabric8.kubernetes.api.model.ServiceStatus;
+import io.fabric8.kubernetes.client.AutoAdaptableKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.entando.kubernetes.model.AbstractEntandoClusterInfrastructureTest;
+import org.entando.kubernetes.model.DbServerStatus;
+import org.entando.kubernetes.model.EntandoDeploymentPhase;
+import org.entando.kubernetes.model.WebServerStatus;
+import org.entando.kubernetes.model.infrastructure.DoneableEntandoClusterInfrastructure;
+import org.entando.kubernetes.model.infrastructure.EntandoClusterInfrastructure;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("inter-process")
+public class EntandoClusterInfrastructureIntegratedTest extends AbstractEntandoClusterInfrastructureTest {
+
+    private final KubernetesClient client = new AutoAdaptableKubernetesClient();
+
+    @Override
+    public KubernetesClient getClient() {
+        return client;
+    }
+
+    @Override
+    protected DoneableEntandoClusterInfrastructure editEntandoClusterInfrastructure(EntandoClusterInfrastructure keycloakServer)
+            throws InterruptedException {
+        entandoInfrastructure().inNamespace(MY_NAMESPACE).create(keycloakServer);
+        return entandoInfrastructure().inNamespace(MY_NAMESPACE).withName(MY_ENTANDO_CLUSTER_INFRASTRUCTURE).edit();
+    }
+
+    @Test
+    public void multipleStatuses() throws InterruptedException {
+        super.testCreateEntandoClusterInfrastructure();
+        entandoInfrastructure().inNamespace(MY_NAMESPACE).withName(MY_ENTANDO_CLUSTER_INFRASTRUCTURE).edit()
+                .withPhase(EntandoDeploymentPhase.STARTED).done();
+        DbServerStatus dbStatus = new DbServerStatus("db-qualifier");
+        dbStatus.setPodStatus(new PodStatus());
+        entandoInfrastructure().inNamespace(MY_NAMESPACE).withName(MY_ENTANDO_CLUSTER_INFRASTRUCTURE).edit().withStatus(dbStatus).done();
+        WebServerStatus status1 = new WebServerStatus("server");
+        entandoInfrastructure().inNamespace(MY_NAMESPACE).withName(MY_ENTANDO_CLUSTER_INFRASTRUCTURE).edit().withStatus(status1).done();
+        status1.setServiceStatus(new ServiceStatus(new LoadBalancerStatus()));
+        entandoInfrastructure().inNamespace(MY_NAMESPACE).withName(MY_ENTANDO_CLUSTER_INFRASTRUCTURE).edit().withStatus(status1).done();
+    }
+
+}

--- a/src/test/java/org/entando/kubernetes/model/interprocesstest/EntandoPluginIntegratedTest.java
+++ b/src/test/java/org/entando/kubernetes/model/interprocesstest/EntandoPluginIntegratedTest.java
@@ -15,13 +15,13 @@ public class EntandoPluginIntegratedTest extends AbstractEntandoPluginTest {
     private final KubernetesClient client = new AutoAdaptableKubernetesClient();
 
     @Override
-    protected DoneableEntandoPlugin editEntandoPlugin(EntandoPlugin entandoPlugin) {
+    protected DoneableEntandoPlugin editEntandoPlugin(EntandoPlugin entandoPlugin) throws InterruptedException {
         entandoPlugins().inNamespace(MY_NAMESPACE).create(entandoPlugin);
         return entandoPlugins().inNamespace(MY_NAMESPACE).withName(MY_PLUGIN).edit();
     }
 
     @Override
-    protected KubernetesClient getClient() {
+    public KubernetesClient getClient() {
         return client;
     }
 

--- a/src/test/java/org/entando/kubernetes/model/interprocesstest/ExternalDatabaseIntegratedTest.java
+++ b/src/test/java/org/entando/kubernetes/model/interprocesstest/ExternalDatabaseIntegratedTest.java
@@ -17,12 +17,12 @@ public class ExternalDatabaseIntegratedTest extends AbstractExternalDatabaseTest
     private final KubernetesClient client = new AutoAdaptableKubernetesClient();
 
     @Override
-    protected KubernetesClient getClient() {
+    public KubernetesClient getClient() {
         return client;
     }
 
     @Override
-    protected DoneableExternalDatabase editExternalDatabase(ExternalDatabase externalDatabase) {
+    protected DoneableExternalDatabase editExternalDatabase(ExternalDatabase externalDatabase) throws InterruptedException {
         externalDatabases().inNamespace(MY_NAMESPACE).create(externalDatabase);
         return externalDatabases().inNamespace(MY_NAMESPACE).withName(MY_EXTERNAL_DATABASE).edit();
     }

--- a/src/test/java/org/entando/kubernetes/model/interprocesstest/KeycloakServerIntegratedTest.java
+++ b/src/test/java/org/entando/kubernetes/model/interprocesstest/KeycloakServerIntegratedTest.java
@@ -20,18 +20,18 @@ public class KeycloakServerIntegratedTest extends AbstractKeycloakServerTest {
     private final KubernetesClient client = new AutoAdaptableKubernetesClient();
 
     @Override
-    protected KubernetesClient getClient() {
+    public KubernetesClient getClient() {
         return client;
     }
 
     @Override
-    protected DoneableKeycloakServer editKeycloakServer(KeycloakServer keycloakServer) {
+    protected DoneableKeycloakServer editKeycloakServer(KeycloakServer keycloakServer) throws InterruptedException {
         keycloakServers().inNamespace(MY_NAMESPACE).create(keycloakServer);
         return keycloakServers().inNamespace(MY_NAMESPACE).withName(MY_KEYCLOAK).edit();
     }
 
     @Test
-    public void multipleStatuses() {
+    public void multipleStatuses() throws InterruptedException {
         super.testCreateKeycloakServer();
         keycloakServers().inNamespace(MY_NAMESPACE).withName(MY_KEYCLOAK).edit().withPhase(EntandoDeploymentPhase.STARTED).done();
         DbServerStatus dbStatus = new DbServerStatus("db-qualifier");


### PR DESCRIPTION
Had to split up the KeycloakServer custom resource into KeycloakServer (just Keycloak and its database), and EntandoClusterInfrastructure (UserManagementService, EntandoK8Service, and eventually also DigitalExchange)