### PR TITLE
Some minor fixes to support the AppPluginLink CRD

### DIFF
--- a/src/main/java/org/entando/kubernetes/model/link/EntandoAppPluginLink.java
+++ b/src/main/java/org/entando/kubernetes/model/link/EntandoAppPluginLink.java
@@ -48,7 +48,7 @@ public class EntandoAppPluginLink extends CustomResource implements EntandoCusto
 
     @Override
     public EntandoCustomResourceStatus getStatus() {
-        return entandoStatus;
+        return entandoStatus == null ? entandoStatus = new EntandoCustomResourceStatus() : entandoStatus;
     }
 
     @Override

--- a/src/main/java/org/entando/kubernetes/model/link/EntandoAppPluginLinkOperationFactory.java
+++ b/src/main/java/org/entando/kubernetes/model/link/EntandoAppPluginLinkOperationFactory.java
@@ -12,7 +12,7 @@ import java.util.List;
 public final class EntandoAppPluginLinkOperationFactory {
 
     private static final int NOT_FOUND = 404;
-    private static CustomResourceDefinition EntandoAppPluginLinkCrd;
+    private static CustomResourceDefinition entandoAppPluginLinkCrd;
 
     private EntandoAppPluginLinkOperationFactory() {
     }
@@ -21,14 +21,14 @@ public final class EntandoAppPluginLinkOperationFactory {
             DoneableEntandoAppPluginLink> produceAllEntandoAppPluginLinks(
             KubernetesClient client) throws InterruptedException {
         synchronized (EntandoAppPluginLinkOperationFactory.class) {
-            EntandoAppPluginLinkCrd = client.customResourceDefinitions().withName(EntandoAppPluginLink.CRD_NAME).get();
-            if (EntandoAppPluginLinkCrd == null) {
+            entandoAppPluginLinkCrd = client.customResourceDefinitions().withName(EntandoAppPluginLink.CRD_NAME).get();
+            if (entandoAppPluginLinkCrd == null) {
                 List<HasMetadata> list = client.load(Thread.currentThread().getContextClassLoader()
                         .getResourceAsStream("crd/EntandoAppPluginLinkCRD.yaml")).get();
-                EntandoAppPluginLinkCrd = (CustomResourceDefinition) list.get(0);
+                entandoAppPluginLinkCrd = (CustomResourceDefinition) list.get(0);
                 // see issue https://github.com/fabric8io/kubernetes-client/issues/1486
-                EntandoAppPluginLinkCrd.getSpec().getValidation().getOpenAPIV3Schema().setDependencies(null);
-                client.customResourceDefinitions().create(EntandoAppPluginLinkCrd);
+                entandoAppPluginLinkCrd.getSpec().getValidation().getOpenAPIV3Schema().setDependencies(null);
+                client.customResourceDefinitions().create(entandoAppPluginLinkCrd);
             }
 
         }
@@ -36,7 +36,7 @@ public final class EntandoAppPluginLinkOperationFactory {
                 DoneableEntandoAppPluginLink>
                 oper = (CustomResourceOperationsImpl<EntandoAppPluginLink, EntandoAppPluginLinkList,
                 DoneableEntandoAppPluginLink>) client
-                .customResources(EntandoAppPluginLinkCrd, EntandoAppPluginLink.class, EntandoAppPluginLinkList.class,
+                .customResources(entandoAppPluginLinkCrd, EntandoAppPluginLink.class, EntandoAppPluginLinkList.class,
                         DoneableEntandoAppPluginLink.class);
         while (notAvailable(oper)) {
             sleep(100);

--- a/src/main/java/org/entando/kubernetes/model/link/EntandoAppPluginLinkSpec.java
+++ b/src/main/java/org/entando/kubernetes/model/link/EntandoAppPluginLinkSpec.java
@@ -21,6 +21,7 @@ public class EntandoAppPluginLinkSpec implements KubernetesResource {
     private String entandoPluginName;
 
     public EntandoAppPluginLinkSpec() {
+        //Required for JSON deserialization
     }
 
     public EntandoAppPluginLinkSpec(String entandoAppNamespace, String entandoAppName, String entandoPluginNamespace,

--- a/src/main/java/org/entando/kubernetes/model/link/EntandoAppPluginLinkSpecBuilder.java
+++ b/src/main/java/org/entando/kubernetes/model/link/EntandoAppPluginLinkSpecBuilder.java
@@ -8,6 +8,7 @@ public class EntandoAppPluginLinkSpecBuilder<N extends EntandoAppPluginLinkSpecB
     private String entandoPluginNamespace;
 
     public EntandoAppPluginLinkSpecBuilder() {
+        //Useful
     }
 
     public EntandoAppPluginLinkSpecBuilder(EntandoAppPluginLinkSpec spec) {

--- a/src/main/java/org/entando/kubernetes/model/plugin/EntandoPlugin.java
+++ b/src/main/java/org/entando/kubernetes/model/plugin/EntandoPlugin.java
@@ -11,6 +11,7 @@ import io.fabric8.kubernetes.client.CustomResource;
 import java.util.Optional;
 import org.entando.kubernetes.model.EntandoCustomResource;
 import org.entando.kubernetes.model.EntandoCustomResourceStatus;
+import org.entando.kubernetes.model.HasIngress;
 import org.entando.kubernetes.model.RequiresKeycloak;
 
 @JsonSerialize
@@ -18,7 +19,7 @@ import org.entando.kubernetes.model.RequiresKeycloak;
 @JsonInclude(Include.NON_NULL)
 @JsonAutoDetect(fieldVisibility = Visibility.ANY, isGetterVisibility = Visibility.NONE, getterVisibility = Visibility.NONE,
         setterVisibility = Visibility.NONE)
-public class EntandoPlugin extends CustomResource implements EntandoCustomResource, RequiresKeycloak {
+public class EntandoPlugin extends CustomResource implements EntandoCustomResource, RequiresKeycloak, HasIngress {
 
     public static final String CRD_NAME = "entandoplugins.entando.org";
 
@@ -66,5 +67,15 @@ public class EntandoPlugin extends CustomResource implements EntandoCustomResour
     @Override
     public Optional<String> getKeycloakSecretToUse() {
         return spec.getKeycloakSecretToUse();
+    }
+
+    @Override
+    public Optional<String> getIngressHostName() {
+        return spec.getIngressHostName();
+    }
+
+    @Override
+    public Optional<String> getTlsSecretName() {
+        return spec.getTlsSecretName();
     }
 }

--- a/src/main/java/org/entando/kubernetes/model/plugin/EntandoPluginSpec.java
+++ b/src/main/java/org/entando/kubernetes/model/plugin/EntandoPluginSpec.java
@@ -23,13 +23,13 @@ import org.entando.kubernetes.model.RequiresKeycloak;
         setterVisibility = Visibility.NONE)
 public class EntandoPluginSpec implements RequiresKeycloak {
 
-    private String entandoAppName;
-    private String entandoAppNamespace;
     private String image;
     private Integer replicas = 1;
     private DbmsImageVendor dbms;
     private PluginSecurityLevel securityLevel;
     private List<String> connectionConfigNames = new ArrayList<>();
+    private String tlsSecretName;
+    private String ingressHostName;
     private List<ExpectedRole> roles = new ArrayList<>();
     private List<Permission> permissions = new ArrayList<>();
     private Map<String, Object> parameters = new ConcurrentHashMap<>();
@@ -48,25 +48,27 @@ public class EntandoPluginSpec implements RequiresKeycloak {
 
     @SuppressWarnings("PMD.ExcessiveParameterList")
     //Because the typical builder pattern requires a full constructor
-    EntandoPluginSpec(String entandoAppNamespace, String entandoAppName, String image, DbmsImageVendor dbms,
+    EntandoPluginSpec(String image, DbmsImageVendor dbms,
             Integer replicas, String ingressPath, String keycloakSecretToUse,
-            String healthCheckPath, PluginSecurityLevel securityLevel, List<ExpectedRole> roles, List<Permission> permissions,
+            String healthCheckPath, PluginSecurityLevel securityLevel, String tlsSecretName,
+            String ingressHostName, List<ExpectedRole> roles, List<Permission> permissions,
             Map<String, Object> parameters, List<String> connectionConfigNames, String clusterInfrastructureToUse) {
         this();
-        this.entandoAppNamespace = entandoAppNamespace;
-        this.entandoAppName = entandoAppName;
         this.image = image;
         this.dbms = dbms;
         this.replicas = replicas;
         this.ingressPath = ingressPath;
         this.keycloakSecretToUse = keycloakSecretToUse;
         this.healthCheckPath = healthCheckPath;
+        this.tlsSecretName = tlsSecretName;
+        this.ingressHostName = ingressHostName;
         this.roles = roles;
         this.permissions = permissions;
         this.parameters = parameters;
         this.connectionConfigNames = connectionConfigNames;
         this.securityLevel = securityLevel;
         this.clusterInfrastructureToUse = clusterInfrastructureToUse;
+
     }
 
     public Map<String, Object> getParameters() {
@@ -77,20 +79,12 @@ public class EntandoPluginSpec implements RequiresKeycloak {
         return ofNullable(securityLevel);
     }
 
-    public String getEntandoAppNamespace() {
-        return entandoAppNamespace;
-    }
-
     public String getImage() {
         return image;
     }
 
     public Integer getReplicas() {
         return replicas;
-    }
-
-    public String getEntandoAppName() {
-        return entandoAppName;
     }
 
     public Optional<DbmsImageVendor> getDbms() {
@@ -126,4 +120,11 @@ public class EntandoPluginSpec implements RequiresKeycloak {
         return connectionConfigNames;
     }
 
+    public Optional<String> getTlsSecretName() {
+        return ofNullable(tlsSecretName);
+    }
+
+    public Optional<String> getIngressHostName() {
+        return ofNullable(ingressHostName);
+    }
 }

--- a/src/main/java/org/entando/kubernetes/model/plugin/EntandoPluginSpecBuilder.java
+++ b/src/main/java/org/entando/kubernetes/model/plugin/EntandoPluginSpecBuilder.java
@@ -6,7 +6,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.entando.kubernetes.model.DbmsImageVendor;
 
-@SuppressWarnings("PMD.TooManyMethods")
+@SuppressWarnings({"PMD.TooManyMethods"})
 //TODO remove deprecated methods
 public class EntandoPluginSpecBuilder<N extends EntandoPluginSpecBuilder> {
 
@@ -14,8 +14,6 @@ public class EntandoPluginSpecBuilder<N extends EntandoPluginSpecBuilder> {
     private final List<ExpectedRole> roles;
     private final List<Permission> permissions;
     private final Map<String, Object> parameters;
-    private String entandoAppName;
-    private String entandoAppNamespace;
     private String image;
     private int replicas = 1;
     private DbmsImageVendor dbms;
@@ -24,6 +22,8 @@ public class EntandoPluginSpecBuilder<N extends EntandoPluginSpecBuilder> {
     private String clusterInfrastructureToUse;
     private String healthCheckPath;
     private PluginSecurityLevel securityLevel;
+    private String tlsSecretName;
+    private String ingressHostName;
 
     public EntandoPluginSpecBuilder() {
         //default constructor required
@@ -38,8 +38,6 @@ public class EntandoPluginSpecBuilder<N extends EntandoPluginSpecBuilder> {
         this.roles = new ArrayList<>(spec.getRoles());
         this.permissions = new ArrayList<>(spec.getPermissions());
         this.parameters = new ConcurrentHashMap<>(spec.getParameters());
-        this.entandoAppName = spec.getEntandoAppName();
-        this.entandoAppNamespace = spec.getEntandoAppNamespace();
         this.image = spec.getImage();
         this.replicas = spec.getReplicas();
         this.dbms = spec.getDbms().orElse(null);
@@ -48,6 +46,8 @@ public class EntandoPluginSpecBuilder<N extends EntandoPluginSpecBuilder> {
         this.healthCheckPath = spec.getHealthCheckPath();
         this.securityLevel = spec.getSecurityLevel().orElse(null);
         this.clusterInfrastructureToUse = spec.getClusterInfrastructureTouse().orElse(null);
+        this.ingressHostName = spec.getIngressHostName().orElse(null);
+        this.tlsSecretName = spec.getTlsSecretName().orElse(null);
     }
 
     public N withClusterInfrastructureToUse(String name) {
@@ -70,6 +70,16 @@ public class EntandoPluginSpecBuilder<N extends EntandoPluginSpecBuilder> {
         return (N) this;
     }
 
+    public N withTlsSecretName(String tlsSecretName) {
+        this.tlsSecretName = tlsSecretName;
+        return (N) this;
+    }
+
+    public N withIngressHostName(String ingressHostName) {
+        this.ingressHostName = ingressHostName;
+        return (N) this;
+    }
+
     public N withImage(String image) {
         this.image = image;
         return (N) this;
@@ -82,12 +92,6 @@ public class EntandoPluginSpecBuilder<N extends EntandoPluginSpecBuilder> {
 
     public N withKeycloakSecretToUse(String name) {
         this.keycloakSecretToUse = name;
-        return (N) this;
-    }
-
-    public N withEntandoApp(String namespace, String name) {
-        this.entandoAppName = name;
-        this.entandoAppNamespace = namespace;
         return (N) this;
     }
 
@@ -122,9 +126,9 @@ public class EntandoPluginSpecBuilder<N extends EntandoPluginSpecBuilder> {
     }
 
     public EntandoPluginSpec build() {
-        return new EntandoPluginSpec(entandoAppNamespace, entandoAppName, image, dbms, replicas, ingressPath,
-                keycloakSecretToUse, healthCheckPath, securityLevel, roles, permissions, parameters,
-                connectionConfigNames, clusterInfrastructureToUse);
+        return new EntandoPluginSpec(image, dbms, replicas, ingressPath, keycloakSecretToUse,
+                healthCheckPath, securityLevel, tlsSecretName, ingressHostName, roles, permissions, parameters, connectionConfigNames,
+                clusterInfrastructureToUse);
     }
 
     public N withHealthCheckPath(String healthCheckPath) {

--- a/src/main/resources/crd/EntandoKeycloakServerCRD.yaml
+++ b/src/main/resources/crd/EntandoKeycloakServerCRD.yaml
@@ -23,6 +23,7 @@ spec:
               pattern: '^(mysql|oracle|postgresql|none)$'
             tlsSecretName:
               type: string
+              pattern: '^([a-z])+([a-z0-9-\.])*[a-z0-9]$'
             ingressHostName:
               type: string
               pattern: '^([A-Za-z0-9-]{1,63}\.)+[[A-Za-z0-9-]{1,63}$'

--- a/src/main/resources/crd/EntandoPluginCRD.yaml
+++ b/src/main/resources/crd/EntandoPluginCRD.yaml
@@ -14,8 +14,12 @@ spec:
       properties:
         spec:
           properties:
-            entandoAppName:
+            ingressHostName:
               type: string
+              pattern: '^([A-Za-z0-9-]{1,63}\.)+[[A-Za-z0-9-]{1,63}$'
+            tlsSecretName:
+              type: string
+              pattern: '^([a-z])+([a-z0-9-\.])*[a-z0-9]$'
             replicas:
               type: integer
               minimum: 1

--- a/src/test/java/org/entando/kubernetes/model/AbstractEntandoAppPluginLinkTest.java
+++ b/src/test/java/org/entando/kubernetes/model/AbstractEntandoAppPluginLinkTest.java
@@ -3,6 +3,7 @@ package org.entando.kubernetes.model;
 import static org.entando.kubernetes.model.link.EntandoAppPluginLinkOperationFactory.produceAllEntandoAppPluginLinks;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 
 import io.fabric8.kubernetes.client.dsl.internal.CustomResourceOperationsImpl;
 import org.entando.kubernetes.model.link.DoneableEntandoAppPluginLink;
@@ -82,6 +83,7 @@ public abstract class AbstractEntandoAppPluginLinkTest implements CustomResource
         assertThat(actual.getSpec().getEntandoPluginName(), is(MY_PLUGIN));
         assertThat(actual.getSpec().getEntandoPluginNamespace(), is(MY_PLUGIN_NAMEPSACE));
         assertThat(actual.getMetadata().getName(), is(MY_PLUGIN));
+        assertThat(actual.getStatus(), is(notNullValue()));
     }
 
     protected abstract DoneableEntandoAppPluginLink editEntandoAppPluginLink(EntandoAppPluginLink entandoAppPluginLink)

--- a/src/test/java/org/entando/kubernetes/model/AbstractEntandoPluginTest.java
+++ b/src/test/java/org/entando/kubernetes/model/AbstractEntandoPluginTest.java
@@ -4,6 +4,7 @@ import static org.entando.kubernetes.model.plugin.EntandoPluginOperationFactory.
 import static org.entando.kubernetes.model.plugin.PluginSecurityLevel.STRICT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 
 import io.fabric8.kubernetes.client.dsl.internal.CustomResourceOperationsImpl;
 import java.util.Arrays;
@@ -19,9 +20,11 @@ import org.junit.jupiter.api.Test;
 
 public abstract class AbstractEntandoPluginTest implements CustomResourceTestUtil {
 
-    public static final String MY_CLUSTER_INFRASTRUCTURE = "my-cluster-infrastructure";
     protected static final String MY_NAMESPACE = "my-namespace";
     protected static final String MY_PLUGIN = "my-plugin";
+    private static final String MY_CLUSTER_INFRASTRUCTURE = "my-cluster-infrastructure";
+    private static final String MYHOST_COM = "myhost.com";
+    private static final String MY_TLS_SECRET = "my-tls-secret";
     private static final String IMAGE = "entando/someplugin:1.0.2";
     private static final String SOME_CONNECTION = "some-connection";
     private static final String INGRESS_PATH = "/plugsy";
@@ -33,7 +36,6 @@ public abstract class AbstractEntandoPluginTest implements CustomResourceTestUti
     private static final String PARAMETER_NAME = "env";
     private static final String PARAMETER_VALUE = "B";
     private static final String MY_KEYCLOAK_SECRET = "my-keycloak-secret";
-    private static final String MY_APP = "my-app";
 
     @BeforeEach
     public void deleteEntandoPlugins() throws InterruptedException {
@@ -54,11 +56,12 @@ public abstract class AbstractEntandoPluginTest implements CustomResourceTestUti
                 .withReplicas(5)
                 .withIngressPath(INGRESS_PATH)
                 .withHealthCheckPath(ACTUATOR_HEALTH)
+                .withIngressHostName(MYHOST_COM)
+                .withTlsSecretName(MY_TLS_SECRET)
                 .withPermission(ENTANDO_APP, SUPERUSER)
                 .withRole(ADMIN, ADMINISTRATOR)
                 .addNewParameter(PARAMETER_NAME, PARAMETER_VALUE)
                 .withSecurityLevel(STRICT)
-                .withEntandoApp(MY_NAMESPACE, MY_APP)
                 .withKeycloakSecretToUse(MY_KEYCLOAK_SECRET)
                 .withClusterInfrastructureToUse(MY_CLUSTER_INFRASTRUCTURE)
                 .endSpec()
@@ -73,8 +76,10 @@ public abstract class AbstractEntandoPluginTest implements CustomResourceTestUti
         assertThat(actual.getSpec().getImage(), is(IMAGE));
         assertThat(actual.getSpec().getKeycloakSecretToUse().get(), is(MY_KEYCLOAK_SECRET));
         assertThat(actual.getKeycloakSecretToUse().get(), is(MY_KEYCLOAK_SECRET));
-        assertThat(actual.getSpec().getEntandoAppName(), is(MY_APP));
-        assertThat(actual.getSpec().getEntandoAppNamespace(), is(MY_NAMESPACE));
+        assertThat(actual.getSpec().getTlsSecretName().get(), is(MY_TLS_SECRET));
+        assertThat(actual.getTlsSecretName().get(), is(MY_TLS_SECRET));
+        assertThat(actual.getSpec().getIngressHostName().get(), is(MYHOST_COM));
+        assertThat(actual.getIngressHostName().get(), is(MYHOST_COM));
         assertThat(actual.getSpec().getConnectionConfigNames(), is(Arrays.asList(SOME_CONNECTION)));
         assertThat(actual.getSpec().getPermissions().get(0).getClientId(), is(ENTANDO_APP));
         assertThat(actual.getSpec().getPermissions().get(0).getRole(), is(SUPERUSER));
@@ -87,6 +92,7 @@ public abstract class AbstractEntandoPluginTest implements CustomResourceTestUti
         assertThat(actual.getSpec().getReplicas(), is(5));
         assertThat(actual.getSpec().getClusterInfrastructureTouse().get(), is(MY_CLUSTER_INFRASTRUCTURE));
         assertThat(actual.getMetadata().getName(), is(MY_PLUGIN));
+        assertThat(actual.getStatus(), is(notNullValue()));
     }
 
     @Test
@@ -108,7 +114,6 @@ public abstract class AbstractEntandoPluginTest implements CustomResourceTestUti
                 .withRole("user", "User")
                 .addNewParameter(PARAMETER_NAME, "A")
                 .withSecurityLevel(STRICT)
-                .withEntandoApp("somenamespace", "another-app")
                 .withKeycloakSecretToUse("another-keycloak-secret")
                 .withClusterInfrastructureToUse("another-cluster-infrastructure")
                 .endSpec()
@@ -125,11 +130,12 @@ public abstract class AbstractEntandoPluginTest implements CustomResourceTestUti
                 .withConnectionConfigNames(Arrays.asList(SOME_CONNECTION))
                 .withReplicas(5)
                 .withHealthCheckPath(ACTUATOR_HEALTH)
+                .withIngressHostName(MYHOST_COM)
+                .withTlsSecretName(MY_TLS_SECRET)
                 .withPermissions(Arrays.asList(new Permission(ENTANDO_APP, SUPERUSER)))
                 .withRoles(Arrays.asList(new ExpectedRole(ADMIN, ADMINISTRATOR)))
                 .withParameters(Collections.singletonMap(PARAMETER_NAME, PARAMETER_VALUE))
                 .withSecurityLevel(STRICT)
-                .withEntandoApp(MY_NAMESPACE, MY_APP)
                 .withKeycloakSecretToUse(MY_KEYCLOAK_SECRET)
                 .withClusterInfrastructureToUse(MY_CLUSTER_INFRASTRUCTURE)
                 .endSpec()
@@ -142,8 +148,10 @@ public abstract class AbstractEntandoPluginTest implements CustomResourceTestUti
         assertThat(actual.getSpec().getImage(), is(IMAGE));
         assertThat(actual.getSpec().getKeycloakSecretToUse().get(), is(MY_KEYCLOAK_SECRET));
         assertThat(actual.getKeycloakSecretToUse().get(), is(MY_KEYCLOAK_SECRET));
-        assertThat(actual.getSpec().getEntandoAppName(), is(MY_APP));
-        assertThat(actual.getSpec().getEntandoAppNamespace(), is(MY_NAMESPACE));
+        assertThat(actual.getSpec().getTlsSecretName().get(), is(MY_TLS_SECRET));
+        assertThat(actual.getTlsSecretName().get(), is(MY_TLS_SECRET));
+        assertThat(actual.getSpec().getIngressHostName().get(), is(MYHOST_COM));
+        assertThat(actual.getIngressHostName().get(), is(MYHOST_COM));
         assertThat(actual.getSpec().getConnectionConfigNames(), is(Arrays.asList(SOME_CONNECTION)));
         assertThat(actual.getSpec().getPermissions().get(0).getClientId(), is(ENTANDO_APP));
         assertThat(actual.getSpec().getPermissions().get(0).getRole(), is(SUPERUSER));


### PR DESCRIPTION
I made the EntandoPlugin a HasIngress implementation as it is useful to test it's public resources e.g. /actuator/health
I removed the requirement for an EntandoPlugin to point to an EntandoApp